### PR TITLE
Allow higher thread level returned at shmem init

### DIFF
--- a/test/performance/shmem_perf_suite/bw_common.h
+++ b/test/performance/shmem_perf_suite/bw_common.h
@@ -390,7 +390,7 @@ int bw_init_data_stream(perf_metrics_t * const metric_info,
 #if defined(ENABLE_THREADS)
     int tl;
     shmem_init_thread(metric_info->thread_safety, &tl);
-    if(tl != metric_info->thread_safety) {
+    if(tl < metric_info->thread_safety) {
         fprintf(stderr,"Could not initialize with requested thread "
                 "level %d: got %d\n", metric_info->thread_safety, tl);
         return -1;

--- a/test/performance/shmem_perf_suite/latency_common.h
+++ b/test/performance/shmem_perf_suite/latency_common.h
@@ -143,7 +143,7 @@ int latency_init_resources(int argc, char *argv[],
 #if defined(ENABLE_THREADS)
     int tl;
     shmem_init_thread(metric_info->thread_safety, &tl);
-    if(tl != metric_info->thread_safety) {
+    if(tl < metric_info->thread_safety) {
         fprintf(stderr,"Could not initialize with requested thread "
                 "level %d: got %d\n", metric_info->thread_safety, tl);
         return -1;

--- a/test/unit/query_thread.c
+++ b/test/unit/query_thread.c
@@ -37,7 +37,7 @@ main(int argc, char* argv[])
     int tl, ret;
     ret = shmem_init_thread(SHMEM_THREAD_FUNNELED, &tl);
 
-    if (tl != SHMEM_THREAD_FUNNELED || ret != 0) {
+    if (tl < SHMEM_THREAD_FUNNELED || ret != 0) {
         printf("Init failed (requested thread level %d, got %d, ret %d)\n",
                SHMEM_THREAD_FUNNELED, tl, ret);
         if (ret == 0) {
@@ -54,7 +54,7 @@ main(int argc, char* argv[])
     printf("%d: Query result for thread level %d\n", shmem_my_pe(), provided);
 
 #if defined(ENABLE_THREADS)
-    if (provided != SHMEM_THREAD_FUNNELED) 
+    if (provided < SHMEM_THREAD_FUNNELED)
         shmem_global_exit(1);
 #else
     if (provided != SHMEM_THREAD_SINGLE && provided != SHMEM_THREAD_FUNNELED && 


### PR DESCRIPTION
The SHMEM library may internally use a thread safety which is higher than that required by the user. For instance, OSHMPI always enables the async thread in order to ensure full progress. This would require the thread multiple safety even if the user requests only thread funneled. 

This situation is allowed by the standard. Thus, the SOS test suite should return error only if the provided thread level is lower than the requested level.