### PR TITLE
Add shmemx_wtime fadd_nbi.

### DIFF
--- a/test/unit/fadd_nbi.c
+++ b/test/unit/fadd_nbi.c
@@ -32,6 +32,15 @@
 
 long ctr = 0;
 
+#ifndef HAVE_SHMEMX_WTIME
+#include <sys/time.h>
+static double shmemx_wtime(void) {
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    return (double) tv.tv_sec + (double) tv.tv_usec / 1000000.0;
+}
+#endif /* HAVE_SHMEMX_WTIME */
+
 int main(void) {
     int me, npes, i;
     long *out;


### PR DESCRIPTION
fadd_nbi is missing the definition of shmemx_wtime when building with external library that does not have it.
Adding it the same way as other unit tests.