### PR TITLE
SOS v1.5.2+ updates (reduce types, C++, wtime)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@ Copyright 2011 Sandia Corporation. Under the terms of Contract
 DE-AC04-94AL85000 with Sandia Corporation, the U.S.  Government
 retains certain rights in this software.
 
-Copyright (c) 2017 Intel Corporation. All rights reserved.
+Copyright (c) 2023 Intel Corporation. All rights reserved.
 This software is available to you under the BSD license.
 
 COPYRIGHT

--- a/test/include/Makefile.am
+++ b/test/include/Makefile.am
@@ -13,4 +13,5 @@
 
 noinst_HEADERS = \
 	uthash.h \
-	pthread_barrier.h
+	pthread_barrier.h \
+	tests_sos/wtime.h

--- a/test/include/tests_sos/wtime.h
+++ b/test/include/tests_sos/wtime.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2011 Sandia Corporation. Under the terms of Contract
+ * DE-AC04-94AL85000 with Sandia Corporation, the U.S.  Government
+ * retains certain rights in this software.
+ *
+ * Copyright (c) 2023 Intel Corporation. All rights reserved.
+ * This software is available to you under the BSD license.
+ *
+ * This file is part of the Sandia OpenSHMEM software package. For license
+ * information, see the LICENSE file in the top level directory of the
+ * distribution. */
+
+#include <sys/time.h>
+
+/* This is the same implementation as shmemx_wtime() in SOS, but is provided
+ * for the convenience of implementations that do not define shmemx_wtime() */
+#ifndef HAVE_SHMEMX_WTIME
+static inline double tests_sos_wtime(void)
+{
+    double wtime = 0.0;
+
+#ifdef HAVE_CLOCK_GETTIME
+    struct timespec tv;
+    clock_gettime(CLOCK_MONOTONIC, &tv);
+    wtime = tv.tv_sec;
+    wtime += (double)tv.tv_nsec / 1.0e9;
+#else
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    wtime = tv.tv_sec;
+    wtime += (double)tv.tv_usec / 1.0e6;
+#endif
+    return wtime;
+}
+#else
+static inline double tests_sos_wtime(void)
+{
+    return shmemx_wtime();
+}
+#endif /* HAVE_SHMEMX_WTIME */

--- a/test/shmemx/Makefile.am
+++ b/test/shmemx/Makefile.am
@@ -20,8 +20,9 @@ endif
 
 if SHMEMX_TESTS
 check_PROGRAMS += \
-    perf_counter \
-    shmem_malloc_with_hints
+	perf_counter \
+	shmemx_team_node \
+	shmem_malloc_with_hints
 
 if HAVE_PTHREADS
 check_PROGRAMS += \

--- a/test/shmemx/cxx_test_shmem_test.cpp
+++ b/test/shmemx/cxx_test_shmem_test.cpp
@@ -54,11 +54,9 @@ int main(int argc, char* argv[]) {
   shmem_init();
 
   int rc = EXIT_SUCCESS;
-  TEST_SHMEM_TEST(short);
   TEST_SHMEM_TEST(int);
   TEST_SHMEM_TEST(long);
   TEST_SHMEM_TEST(long long);
-  TEST_SHMEM_TEST(unsigned short);
   TEST_SHMEM_TEST(unsigned int);
   TEST_SHMEM_TEST(unsigned long);
   TEST_SHMEM_TEST(unsigned long long);

--- a/test/shmemx/cxx_test_shmem_wait_until.cpp
+++ b/test/shmemx/cxx_test_shmem_wait_until.cpp
@@ -54,11 +54,9 @@ int main(int argc, char* argv[]) {
   shmem_init();
 
   int rc = EXIT_SUCCESS;
-  TEST_SHMEM_WAIT_UNTIL(short);
   TEST_SHMEM_WAIT_UNTIL(int);
   TEST_SHMEM_WAIT_UNTIL(long);
   TEST_SHMEM_WAIT_UNTIL(long long);
-  TEST_SHMEM_WAIT_UNTIL(unsigned short);
   TEST_SHMEM_WAIT_UNTIL(unsigned int);
   TEST_SHMEM_WAIT_UNTIL(unsigned long);
   TEST_SHMEM_WAIT_UNTIL(unsigned long long);

--- a/test/shmemx/shmemx_team_node.c
+++ b/test/shmemx/shmemx_team_node.c
@@ -1,0 +1,54 @@
+/* Copyright (c) 2023 Intel Corporation.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * This file is part of the Sandia OpenSHMEM software package. For license
+ * information, see the LICENSE file in the top level directory of the
+ * distribution.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <shmem.h>
+#include <shmemx.h>
+
+
+int main(void)
+{
+    static long lock = 0;
+
+    shmem_init();
+    int me = shmem_my_pe();
+    int npes = shmem_n_pes();
+
+    int team_shared_npes = shmem_team_n_pes(SHMEMX_TEAM_NODE);
+
+    int *peers = malloc(team_shared_npes * sizeof(int));
+    int num_peers = 0;
+
+    /* Print the team members on SHMEMX_TEAM_NODE */
+    /* Use a lock for cleaner output */
+    shmem_set_lock(&lock);
+
+    printf("[PE: %d] SHMEMX_TEAM_NODE peers: { ", me);
+    for (int i = 0; i < npes; i++) {
+        if (shmem_team_translate_pe(SHMEM_TEAM_WORLD, i,
+                                    SHMEMX_TEAM_NODE) != -1) {
+            peers[num_peers++] = i;
+            printf("%d ", i);
+        }
+    }
+
+    printf("} (num_peers: %d)\n", num_peers);
+
+    fflush(NULL);
+
+    shmem_clear_lock(&lock);
+
+    if (num_peers != team_shared_npes) {
+        shmem_global_exit(1);
+    }
+
+    free(peers);
+    shmem_finalize();
+    return 0;
+}

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -156,6 +156,9 @@ check_PROGRAMS += \
 	cxx_test_shmem_atomic_cswap \
 	cxx_test_shmem_wait_until \
 	cxx_test_shmem_test \
+	cxx_test_shmem_bitwise_reduce \
+	cxx_test_shmem_max_min_reduce \
+	cxx_test_shmem_sum_prod_reduce \
 	cxx_shmem_test_all
 endif
 
@@ -275,3 +278,6 @@ cxx_test_shmem_atomic_swap_SOURCES = cxx_test_shmem_atomic_swap.cpp
 cxx_test_shmem_atomic_cswap_SOURCES = cxx_test_shmem_atomic_cswap.cpp
 cxx_test_shmem_wait_until_SOURCES = cxx_test_shmem_wait_until.cpp
 cxx_test_shmem_test_SOURCES = cxx_test_shmem_test.cpp
+cxx_test_shmem_bitwise_reduce_SOURCES = cxx_test_shmem_bitwise_reduce.cpp
+cxx_test_shmem_max_min_reduce_SOURCES = cxx_test_shmem_max_min_reduce.cpp
+cxx_test_shmem_sum_prod_reduce_SOURCES = cxx_test_shmem_sum_prod_reduce.cpp

--- a/test/unit/bcast_flood.c
+++ b/test/unit/bcast_flood.c
@@ -39,18 +39,10 @@
 #include <assert.h>
 
 #include <shmem.h>
-#include <shmemx.h>
+#include "tests_sos/wtime.h"
 
 static int atoi_scaled(char *s);
 static void usage(char *pgm);
-
-#ifndef HAVE_SHMEMX_WTIME
-static double shmemx_wtime(void) {
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
-    return (double) tv.tv_sec + (double) tv.tv_usec / 1000000.0;
-}
-#endif /* HAVE_SHMEMX_WTIME */
 
 int Verbose=0;
 int Serialize;
@@ -141,13 +133,13 @@ main(int argc, char **argv)
 
     for(time_taken = 0.0, i = 0; i < loops; i++) {
 
-        start_time = shmemx_wtime();
+        start_time = tests_sos_wtime();
 
         shmem_int_broadcast(SHMEM_TEAM_WORLD, target, source, elements, 0);
 
         if (Serialize) shmem_barrier_all();
 
-        time_taken += (shmemx_wtime() - start_time);
+        time_taken += (tests_sos_wtime() - start_time);
 
     }
 

--- a/test/unit/bigget.c
+++ b/test/unit/bigget.c
@@ -40,7 +40,7 @@
 #include <sys/time.h>
 
 #include <shmem.h>
-#include <shmemx.h>
+#include "tests_sos/wtime.h"
 
 #define NUM_ELEMENTS 4194304 // 32 MB by longs
 //#define DFLT_LOOPS 10000
@@ -72,13 +72,6 @@ atoi_scaled(char *s)
     return (int)val;
 }
 
-#ifndef HAVE_SHMEMX_WTIME
-static double shmemx_wtime(void) {
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
-    return (double) tv.tv_sec + (double) tv.tv_usec / 1000000.0;
-}
-#endif /* HAVE_SHMEMX_WTIME */
 
 static void
 usage(char *pgm)
@@ -197,11 +190,11 @@ main(int argc, char **argv)
 
     for(i=0; i < loops; i++) {
 
-        start_time = shmemx_wtime();
+        start_time = tests_sos_wtime();
 
         shmem_int_get( Target, Source, elements, target_pe );
 
-        time_taken += shmemx_wtime() - start_time;
+        time_taken += tests_sos_wtime() - start_time;
 
         if (me==0) {
             if ( Track && i > 0 && ((i % 200) == 0))

--- a/test/unit/bigput.c
+++ b/test/unit/bigput.c
@@ -40,7 +40,7 @@
 #include <sys/time.h>
 
 #include <shmem.h>
-#include <shmemx.h>
+#include "tests_sos/wtime.h"
 
 #define NUM_ELEMENTS 4194304 // 32 MB by longs
 //#define DFLT_LOOPS 10000  // reset when Portals4 can achieve this.
@@ -86,14 +86,6 @@ usage(char *pgm)
         pgm,NUM_ELEMENTS,DFLT_LOOPS);
 }
 
-#if !defined(HAVE_SHMEMX_WTIME)
-static inline double shmemx_wtime(void)
-{
-    struct timeval tv;
-    gettimeofday(&tv, 0);
-    return (double)((tv.tv_usec / 1000000.0) + tv.tv_sec);
-}
-#endif
 
 int
 main(int argc, char **argv)
@@ -200,11 +192,11 @@ main(int argc, char **argv)
 
     for(i=0; i < loops; i++) {
 
-        start_time = shmemx_wtime();
+        start_time = tests_sos_wtime();
 
         shmem_int_put(Target, Source, elements, target_PE);
 
-        time_taken += (shmemx_wtime() - start_time);
+        time_taken += (tests_sos_wtime() - start_time);
 
         if (me==0) {
             if ( Track && i > 0 && ((i % 200) == 0))

--- a/test/unit/cxx_test_shmem_bitwise_reduce.cpp
+++ b/test/unit/cxx_test_shmem_bitwise_reduce.cpp
@@ -1,0 +1,183 @@
+/*
+ *  This test program is derived from a unit test created by Nick Park.
+ *  The original unit test is a work of the U.S. Government and is not subject
+ *  to copyright protection in the United States.  Foreign copyrights may
+ *  apply.
+ *
+ *  Copyright (c) 2023 Intel Corporation. All rights reserved.
+ *  This software is available to you under the BSD license below:
+ *
+ *      Redistribution and use in source and binary forms, with or
+ *      without modification, are permitted provided that the following
+ *      conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <complex.h>
+#include <math.h>
+#include <stdbool.h>
+#include <shmem.h>
+#include <type_traits>
+
+#define MAX_NPES 32
+
+enum op { OP_AND = 0, OP_OR, OP_XOR };
+
+#define REDUCTION(OP, TYPE)                                                   \
+    do {                                                                      \
+        switch (OP) {                                                         \
+            case OP_AND:                                                      \
+                ret = shmem_##TYPE##_and_reduce(SHMEM_TEAM_WORLD, dest, src,  \
+                                                npes);                        \
+                break;                                                        \
+            case OP_OR:                                                       \
+                ret = shmem_##TYPE##_or_reduce(SHMEM_TEAM_WORLD, dest, src,   \
+                                               npes);                         \
+                break;                                                        \
+            case OP_XOR:                                                      \
+                ret = shmem_##TYPE##_xor_reduce(SHMEM_TEAM_WORLD, dest, src,  \
+                                                npes);                        \
+                break;                                                        \
+            default:                                                          \
+                printf("Invalid operation (%d)\n", OP);                       \
+                shmem_global_exit(1);                                         \
+        }                                                                     \
+    } while (0)
+
+#define INIT_SRC_BUFFER(TYPE)                                                  \
+  do {                                                                         \
+      for (int i = 0; i < MAX_NPES; i++) {                                     \
+          src[i] = (TYPE)1ULL;                                                 \
+      }                                                                        \
+  } while (0)
+
+#define CHECK_DEST_BUFFER(OP, TYPE, CORRECT_VAL)                               \
+  do {                                                                         \
+      for (int i = 0; i < npes; i++) {                                         \
+          if (dest[i] != (TYPE)CORRECT_VAL) {                                  \
+              printf("PE %i received incorrect value with "                    \
+                     "TEST_SHMEM_REDUCE(%s, %s)\n", mype, #OP, #TYPE);         \
+              rc = EXIT_FAILURE;                                               \
+          }                                                                    \
+      }                                                                        \
+  } while (0)
+
+#define TEST_SHMEM_REDUCE(OP, TYPENAME, TYPE)                                  \
+  do {                                                                         \
+    static TYPE src[MAX_NPES];                                                 \
+    static TYPE dest[MAX_NPES];                                                \
+    int ret;                                                                   \
+                                                                               \
+    INIT_SRC_BUFFER(TYPE);                                                     \
+    REDUCTION(OP, TYPENAME);                                                   \
+                                                                               \
+    if (ret != 0) {                                                            \
+        printf("Reduction returned non-zero value (%i) on PE (%i) with "       \
+               "TEST_SHMEM_REDUCE(%s, %s)\n", ret, mype, #OP, #TYPE);          \
+        rc = EXIT_FAILURE;                                                     \
+    }                                                                          \
+                                                                               \
+    shmem_barrier_all();                                                       \
+                                                                               \
+    switch (OP) {                                                              \
+      case OP_AND:                                                             \
+          CHECK_DEST_BUFFER(OP, TYPE, 1ULL);                                   \
+          break;                                                               \
+      case OP_OR:                                                              \
+          CHECK_DEST_BUFFER(OP, TYPE, 1ULL);                                   \
+          break;                                                               \
+      case OP_XOR:                                                             \
+          CHECK_DEST_BUFFER(OP, TYPE, (TYPE)(npes % 2 ? 1ULL : 0ULL));         \
+          break;                                                               \
+      default:                                                                 \
+          printf("Invalid operation (%d)\n", OP);                              \
+          shmem_global_exit(1);                                                \
+    }                                                                          \
+  } while (0)
+
+
+int main(void) {
+
+    shmem_init();
+
+    int rc = EXIT_SUCCESS;
+
+    const int mype = shmem_my_pe();
+    const int npes = shmem_n_pes();
+
+    if (npes > MAX_NPES) {
+        if (mype == 0)
+            fprintf(stderr, "ERR - Requires less than %d PEs\n", MAX_NPES);
+        shmem_global_exit(1);
+    }
+
+    TEST_SHMEM_REDUCE(OP_AND, uchar, unsigned char);
+    TEST_SHMEM_REDUCE(OP_AND, ushort, unsigned short);
+    TEST_SHMEM_REDUCE(OP_AND, uint, unsigned int);
+    TEST_SHMEM_REDUCE(OP_AND, ulong, unsigned long);
+    TEST_SHMEM_REDUCE(OP_AND, ulonglong, unsigned long long);
+    TEST_SHMEM_REDUCE(OP_AND, int8, int8_t);
+    TEST_SHMEM_REDUCE(OP_AND, int16, int16_t);
+    TEST_SHMEM_REDUCE(OP_AND, int32, int32_t);
+    TEST_SHMEM_REDUCE(OP_AND, int64, int64_t);
+    TEST_SHMEM_REDUCE(OP_AND, uint8, uint8_t);
+    TEST_SHMEM_REDUCE(OP_AND, uint16, uint16_t);
+    TEST_SHMEM_REDUCE(OP_AND, uint32, uint32_t);
+    TEST_SHMEM_REDUCE(OP_AND, uint64, uint64_t);
+    TEST_SHMEM_REDUCE(OP_AND, size, size_t);
+
+    TEST_SHMEM_REDUCE(OP_OR, uchar, unsigned char);
+    TEST_SHMEM_REDUCE(OP_OR, ushort, unsigned short);
+    TEST_SHMEM_REDUCE(OP_OR, uint, unsigned int);
+    TEST_SHMEM_REDUCE(OP_OR, ulong, unsigned long);
+    TEST_SHMEM_REDUCE(OP_OR, ulonglong, unsigned long long);
+    TEST_SHMEM_REDUCE(OP_OR, int8, int8_t);
+    TEST_SHMEM_REDUCE(OP_OR, int16, int16_t);
+    TEST_SHMEM_REDUCE(OP_OR, int32, int32_t);
+    TEST_SHMEM_REDUCE(OP_OR, int64, int64_t);
+    TEST_SHMEM_REDUCE(OP_OR, uint8, uint8_t);
+    TEST_SHMEM_REDUCE(OP_OR, uint16, uint16_t);
+    TEST_SHMEM_REDUCE(OP_OR, uint32, uint32_t);
+    TEST_SHMEM_REDUCE(OP_OR, uint64, uint64_t);
+    TEST_SHMEM_REDUCE(OP_OR, size, size_t);
+
+    TEST_SHMEM_REDUCE(OP_XOR, uchar, unsigned char);
+    TEST_SHMEM_REDUCE(OP_XOR, ushort, unsigned short);
+    TEST_SHMEM_REDUCE(OP_XOR, uint, unsigned int);
+    TEST_SHMEM_REDUCE(OP_XOR, ulong, unsigned long);
+    TEST_SHMEM_REDUCE(OP_XOR, ulonglong, unsigned long long);
+    TEST_SHMEM_REDUCE(OP_XOR, int8, int8_t);
+    TEST_SHMEM_REDUCE(OP_XOR, int16, int16_t);
+    TEST_SHMEM_REDUCE(OP_XOR, int32, int32_t);
+    TEST_SHMEM_REDUCE(OP_XOR, int64, int64_t);
+    TEST_SHMEM_REDUCE(OP_XOR, uint8, uint8_t);
+    TEST_SHMEM_REDUCE(OP_XOR, uint16, uint16_t);
+    TEST_SHMEM_REDUCE(OP_XOR, uint32, uint32_t);
+    TEST_SHMEM_REDUCE(OP_XOR, uint64, uint64_t);
+    TEST_SHMEM_REDUCE(OP_XOR, size, size_t);
+
+    fprintf(stdout, "Test passed with ret = %d\n", rc);
+  
+    shmem_finalize();
+    return rc;
+}

--- a/test/unit/cxx_test_shmem_max_min_reduce.cpp
+++ b/test/unit/cxx_test_shmem_max_min_reduce.cpp
@@ -1,0 +1,206 @@
+/*
+ *  This test program is derived from a unit test created by Nick Park.
+ *  The original unit test is a work of the U.S. Government and is not subject
+ *  to copyright protection in the United States.  Foreign copyrights may
+ *  apply.
+ *
+ *  Copyright (c) 2023 Intel Corporation. All rights reserved.
+ *  This software is available to you under the BSD license below:
+ *
+ *      Redistribution and use in source and binary forms, with or
+ *      without modification, are permitted provided that the following
+ *      conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <complex.h>
+#include <math.h>
+#include <stdbool.h>
+#include <shmem.h>
+#include <type_traits>
+
+#define MAX_NPES 32
+
+enum op { OP_MAX, OP_MIN };
+
+const double FLOATING_POINT_TOLERANCE = 1e-6;
+
+#define REDUCTION(OP, TYPE)                                                   \
+    do {                                                                      \
+        switch (OP) {                                                         \
+            case OP_MAX:                                                      \
+                ret = shmem_##TYPE##_max_reduce(SHMEM_TEAM_WORLD, dest, src,  \
+                                                npes);                        \
+                break;                                                        \
+            case OP_MIN:                                                      \
+                ret = shmem_##TYPE##_min_reduce(SHMEM_TEAM_WORLD, dest, src,  \
+                                               npes);                         \
+                break;                                                        \
+            default:                                                          \
+                printf("Invalid operation (%d)\n", OP);                       \
+                shmem_global_exit(1);                                         \
+        }                                                                     \
+    } while (0)
+
+#define INIT_SRC_BUFFER(TYPE)                                                  \
+  do {                                                                         \
+      for (int i = 0; i < MAX_NPES; i++) {                                     \
+          src[i] = (TYPE)1ULL;                                                 \
+      }                                                                        \
+  } while (0)
+
+#define CHECK_DEST_BUFFER(OP, TYPE, CORRECT_VAL)                               \
+  do {                                                                         \
+      for (int i = 0; i < npes; i++) {                                         \
+          if (dest[i] != (TYPE)CORRECT_VAL) {                                  \
+              printf("PE %i received incorrect value with "                    \
+                     "TEST_SHMEM_REDUCE(%s, %s)\n", mype, #OP, #TYPE);         \
+              rc = EXIT_FAILURE;                                               \
+          }                                                                    \
+      }                                                                        \
+  } while (0)
+
+#define CHECK_DEST_BUFFER_FP(OP, TYPE, CORRECT_VAL, TOLERANCE)                 \
+  do {                                                                         \
+      for (int i = 0; i < npes; i++) {                                         \
+          if (fabsl(creal(dest[i]) - creal((TYPE)CORRECT_VAL)) > TOLERANCE) {  \
+              printf("PE %i received incorrect real value with "               \
+                     "TEST_SHMEM_REDUCE(%s, %s)\n", mype, #OP, #TYPE);         \
+              rc = EXIT_FAILURE;                                               \
+          }                                                                    \
+          if (fabsl(cimag(dest[i]) - cimag((TYPE)CORRECT_VAL)) > TOLERANCE) {  \
+                printf("PE %i received incorrect imaginary value with "        \
+                       "TEST_SHMEM_REDUCE(%s, %s)\n", mype, #OP, #TYPE);       \
+              rc = EXIT_FAILURE;                                               \
+          }                                                                    \
+      }                                                                        \
+  } while (0)
+
+#define TEST_SHMEM_REDUCE(OP, TYPENAME, TYPE)                                  \
+  do {                                                                         \
+    static TYPE src[MAX_NPES];                                                 \
+    static TYPE dest[MAX_NPES];                                                \
+    int ret;                                                                   \
+    const bool floating_point_val = std::is_floating_point<TYPE>::value;       \
+                                                                               \
+    INIT_SRC_BUFFER(TYPE);                                                     \
+    REDUCTION(OP, TYPENAME);                                                   \
+                                                                               \
+    if (ret != 0) {                                                            \
+        printf("Reduction returned non-zero value (%i) on PE (%i) with "       \
+               "TEST_SHMEM_REDUCE(%s, %s)\n", ret, mype, #OP, #TYPE);          \
+        rc = EXIT_FAILURE;                                                     \
+    }                                                                          \
+                                                                               \
+    shmem_barrier_all();                                                       \
+                                                                               \
+    switch (OP) {                                                              \
+      case OP_MAX:                                                             \
+          if (floating_point_val)                                              \
+              CHECK_DEST_BUFFER_FP(OP, TYPE, 1ULL, FLOATING_POINT_TOLERANCE);  \
+          else                                                                 \
+              CHECK_DEST_BUFFER(OP, TYPE, 1ULL);                               \
+          break;                                                               \
+      case OP_MIN:                                                             \
+          if (floating_point_val)                                              \
+              CHECK_DEST_BUFFER_FP(OP, TYPE, 1ULL, FLOATING_POINT_TOLERANCE);  \
+          else                                                                 \
+              CHECK_DEST_BUFFER(OP, TYPE, 1ULL);                               \
+          break;                                                               \
+      default:                                                                 \
+          printf("Invalid operation (%d)\n", OP);                              \
+          shmem_global_exit(1);                                                \
+    }                                                                          \
+  } while (0)
+
+
+int main(void) {
+
+    shmem_init();
+
+    int rc = EXIT_SUCCESS;
+
+    const int mype = shmem_my_pe();
+    const int npes = shmem_n_pes();
+
+    if (npes > MAX_NPES) {
+        if (mype == 0)
+            fprintf(stderr, "ERR - Requires less than %d PEs\n", MAX_NPES);
+        shmem_global_exit(1);
+    }
+
+    TEST_SHMEM_REDUCE(OP_MAX, char, char);
+    TEST_SHMEM_REDUCE(OP_MAX, schar, signed char);
+    TEST_SHMEM_REDUCE(OP_MAX, short, short);
+    TEST_SHMEM_REDUCE(OP_MAX, int, int);
+    TEST_SHMEM_REDUCE(OP_MAX, long, long);
+    TEST_SHMEM_REDUCE(OP_MAX, longlong, long long);
+    TEST_SHMEM_REDUCE(OP_MAX, ptrdiff, ptrdiff_t);
+    TEST_SHMEM_REDUCE(OP_MAX, uchar, unsigned char);
+    TEST_SHMEM_REDUCE(OP_MAX, ushort, unsigned short);
+    TEST_SHMEM_REDUCE(OP_MAX, uint, unsigned int);
+    TEST_SHMEM_REDUCE(OP_MAX, ulong, unsigned long);
+    TEST_SHMEM_REDUCE(OP_MAX, ulonglong, unsigned long long);
+    TEST_SHMEM_REDUCE(OP_MAX, int8, int8_t);
+    TEST_SHMEM_REDUCE(OP_MAX, int16, int16_t);
+    TEST_SHMEM_REDUCE(OP_MAX, int32, int32_t);
+    TEST_SHMEM_REDUCE(OP_MAX, int64, int64_t);
+    TEST_SHMEM_REDUCE(OP_MAX, uint8, uint8_t);
+    TEST_SHMEM_REDUCE(OP_MAX, uint16, uint16_t);
+    TEST_SHMEM_REDUCE(OP_MAX, uint32, uint32_t);
+    TEST_SHMEM_REDUCE(OP_MAX, uint64, uint64_t);
+    TEST_SHMEM_REDUCE(OP_MAX, size, size_t);
+    TEST_SHMEM_REDUCE(OP_MAX, float, float);
+    TEST_SHMEM_REDUCE(OP_MAX, double, double);
+    TEST_SHMEM_REDUCE(OP_MAX, longdouble, long double);
+
+    TEST_SHMEM_REDUCE(OP_MIN, char, char);
+    TEST_SHMEM_REDUCE(OP_MIN, schar, signed char);
+    TEST_SHMEM_REDUCE(OP_MIN, short, short);
+    TEST_SHMEM_REDUCE(OP_MIN, int, int);
+    TEST_SHMEM_REDUCE(OP_MIN, long, long);
+    TEST_SHMEM_REDUCE(OP_MIN, longlong, long long);
+    TEST_SHMEM_REDUCE(OP_MIN, ptrdiff, ptrdiff_t);
+    TEST_SHMEM_REDUCE(OP_MIN, uchar, unsigned char);
+    TEST_SHMEM_REDUCE(OP_MIN, ushort, unsigned short);
+    TEST_SHMEM_REDUCE(OP_MIN, uint, unsigned int);
+    TEST_SHMEM_REDUCE(OP_MIN, ulong, unsigned long);
+    TEST_SHMEM_REDUCE(OP_MIN, ulonglong, unsigned long long);
+    TEST_SHMEM_REDUCE(OP_MIN, int8, int8_t);
+    TEST_SHMEM_REDUCE(OP_MIN, int16, int16_t);
+    TEST_SHMEM_REDUCE(OP_MIN, int32, int32_t);
+    TEST_SHMEM_REDUCE(OP_MIN, int64, int64_t);
+    TEST_SHMEM_REDUCE(OP_MIN, uint8, uint8_t);
+    TEST_SHMEM_REDUCE(OP_MIN, uint16, uint16_t);
+    TEST_SHMEM_REDUCE(OP_MIN, uint32, uint32_t);
+    TEST_SHMEM_REDUCE(OP_MIN, uint64, uint64_t);
+    TEST_SHMEM_REDUCE(OP_MIN, size, size_t);
+    TEST_SHMEM_REDUCE(OP_MIN, float, float);
+    TEST_SHMEM_REDUCE(OP_MIN, double, double);
+    TEST_SHMEM_REDUCE(OP_MIN, longdouble, long double);
+
+    fprintf(stdout, "Test passed with ret = %d\n", rc);
+  
+    shmem_finalize();
+    return rc;
+}

--- a/test/unit/cxx_test_shmem_sum_prod_reduce.cpp
+++ b/test/unit/cxx_test_shmem_sum_prod_reduce.cpp
@@ -1,0 +1,210 @@
+/*
+ *  This test program is derived from a unit test created by Nick Park.
+ *  The original unit test is a work of the U.S. Government and is not subject
+ *  to copyright protection in the United States.  Foreign copyrights may
+ *  apply.
+ *
+ *  Copyright (c) 2023 Intel Corporation. All rights reserved.
+ *  This software is available to you under the BSD license below:
+ *
+ *      Redistribution and use in source and binary forms, with or
+ *      without modification, are permitted provided that the following
+ *      conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <complex.h>
+#include <math.h>
+#include <stdbool.h>
+#include <shmem.h>
+#include <type_traits>
+
+#define MAX_NPES 32
+
+enum op { OP_SUM, OP_PROD };
+
+const double FLOATING_POINT_TOLERANCE = 1e-6;
+
+#define REDUCTION(OP, TYPE)                                                   \
+    do {                                                                      \
+        switch (OP) {                                                         \
+            case OP_SUM:                                                      \
+                ret = shmem_##TYPE##_sum_reduce(SHMEM_TEAM_WORLD, dest, src,  \
+                                                npes);                        \
+                break;                                                        \
+            case OP_PROD:                                                     \
+                ret = shmem_##TYPE##_prod_reduce(SHMEM_TEAM_WORLD, dest, src, \
+                                                 npes);                       \
+                break;                                                        \
+            default:                                                          \
+                printf("Invalid operation (%d)\n", OP);                       \
+                shmem_global_exit(1);                                         \
+        }                                                                     \
+    } while (0)
+
+#define INIT_SRC_BUFFER(TYPE)                                                  \
+  do {                                                                         \
+      for (int i = 0; i < MAX_NPES; i++) {                                     \
+          src[i] = (TYPE)1ULL;                                                 \
+      }                                                                        \
+  } while (0)
+
+#define CHECK_DEST_BUFFER(OP, TYPE, CORRECT_VAL)                               \
+  do {                                                                         \
+      for (int i = 0; i < npes; i++) {                                         \
+          if (dest[i] != (TYPE)CORRECT_VAL) {                                  \
+              printf("PE %i received incorrect value with "                    \
+                     "TEST_SHMEM_REDUCE(%s, %s)\n", mype, #OP, #TYPE);         \
+              rc = EXIT_FAILURE;                                               \
+          }                                                                    \
+      }                                                                        \
+  } while (0)
+
+#define CHECK_DEST_BUFFER_FP(OP, TYPE, CORRECT_VAL, TOLERANCE)                 \
+  do {                                                                         \
+      for (int i = 0; i < npes; i++) {                                         \
+          if (fabsl(creal(dest[i]) - creal((TYPE)CORRECT_VAL)) > TOLERANCE) {  \
+              printf("PE %i received incorrect real value with "               \
+                     "TEST_SHMEM_REDUCE(%s, %s)\n", mype, #OP, #TYPE);         \
+              rc = EXIT_FAILURE;                                               \
+          }                                                                    \
+          if (fabsl(cimag(dest[i]) - cimag((TYPE)CORRECT_VAL)) > TOLERANCE) {  \
+                printf("PE %i received incorrect imaginary value with "        \
+                       "TEST_SHMEM_REDUCE(%s, %s)\n", mype, #OP, #TYPE);       \
+              rc = EXIT_FAILURE;                                               \
+          }                                                                    \
+      }                                                                        \
+  } while (0)
+
+#define TEST_SHMEM_REDUCE(OP, TYPENAME, TYPE)                                  \
+  do {                                                                         \
+    static TYPE src[MAX_NPES];                                                 \
+    static TYPE dest[MAX_NPES];                                                \
+    int ret;                                                                   \
+    const bool floating_point_val = std::is_floating_point<TYPE>::value;       \
+                                                                               \
+    INIT_SRC_BUFFER(TYPE);                                                     \
+    REDUCTION(OP, TYPENAME);                                                   \
+                                                                               \
+    if (ret != 0) {                                                            \
+        printf("Reduction returned non-zero value (%i) on PE (%i) with "       \
+               "TEST_SHMEM_REDUCE(%s, %s)\n", ret, mype, #OP, #TYPE);          \
+        rc = EXIT_FAILURE;                                                     \
+    }                                                                          \
+                                                                               \
+    shmem_barrier_all();                                                       \
+                                                                               \
+    switch (OP) {                                                              \
+      case OP_SUM:                                                             \
+          if (floating_point_val)                                              \
+              CHECK_DEST_BUFFER_FP(OP, TYPE, npes, FLOATING_POINT_TOLERANCE);  \
+          else                                                                 \
+              CHECK_DEST_BUFFER(OP, TYPE, npes);                               \
+          break;                                                               \
+      case OP_PROD:                                                            \
+          if (floating_point_val)                                              \
+              CHECK_DEST_BUFFER_FP(OP, TYPE, 1ULL, FLOATING_POINT_TOLERANCE);  \
+          else                                                                 \
+              CHECK_DEST_BUFFER(OP, TYPE, 1ULL);                               \
+          break;                                                               \
+      default:                                                                 \
+          printf("Invalid operation (%d)\n", OP);                              \
+          shmem_global_exit(1);                                                \
+    }                                                                          \
+  } while (0)
+
+
+int main(void) {
+
+    shmem_init();
+
+    int rc = EXIT_SUCCESS;
+
+    const int mype = shmem_my_pe();
+    const int npes = shmem_n_pes();
+
+    if (npes > MAX_NPES) {
+        if (mype == 0)
+            fprintf(stderr, "ERR - Requires less than %d PEs\n", MAX_NPES);
+        shmem_global_exit(1);
+    }
+
+    TEST_SHMEM_REDUCE(OP_SUM, char, char);
+    TEST_SHMEM_REDUCE(OP_SUM, schar, signed char);
+    TEST_SHMEM_REDUCE(OP_SUM, short, short);
+    TEST_SHMEM_REDUCE(OP_SUM, int, int);
+    TEST_SHMEM_REDUCE(OP_SUM, long, long);
+    TEST_SHMEM_REDUCE(OP_SUM, longlong, long long);
+    TEST_SHMEM_REDUCE(OP_SUM, ptrdiff, ptrdiff_t);
+    TEST_SHMEM_REDUCE(OP_SUM, uchar, unsigned char);
+    TEST_SHMEM_REDUCE(OP_SUM, ushort, unsigned short);
+    TEST_SHMEM_REDUCE(OP_SUM, uint, unsigned int);
+    TEST_SHMEM_REDUCE(OP_SUM, ulong, unsigned long);
+    TEST_SHMEM_REDUCE(OP_SUM, ulonglong, unsigned long long);
+    TEST_SHMEM_REDUCE(OP_SUM, int8, int8_t);
+    TEST_SHMEM_REDUCE(OP_SUM, int16, int16_t);
+    TEST_SHMEM_REDUCE(OP_SUM, int32, int32_t);
+    TEST_SHMEM_REDUCE(OP_SUM, int64, int64_t);
+    TEST_SHMEM_REDUCE(OP_SUM, uint8, uint8_t);
+    TEST_SHMEM_REDUCE(OP_SUM, uint16, uint16_t);
+    TEST_SHMEM_REDUCE(OP_SUM, uint32, uint32_t);
+    TEST_SHMEM_REDUCE(OP_SUM, uint64, uint64_t);
+    TEST_SHMEM_REDUCE(OP_SUM, size, size_t);
+    TEST_SHMEM_REDUCE(OP_SUM, float, float);
+    TEST_SHMEM_REDUCE(OP_SUM, double, double);
+    TEST_SHMEM_REDUCE(OP_SUM, longdouble, long double);
+    TEST_SHMEM_REDUCE(OP_SUM, complexd, double _Complex);
+    TEST_SHMEM_REDUCE(OP_SUM, complexf, float _Complex);
+
+    TEST_SHMEM_REDUCE(OP_PROD, char, char);
+    TEST_SHMEM_REDUCE(OP_PROD, schar, signed char);
+    TEST_SHMEM_REDUCE(OP_PROD, short, short);
+    TEST_SHMEM_REDUCE(OP_PROD, int, int);
+    TEST_SHMEM_REDUCE(OP_PROD, long, long);
+    TEST_SHMEM_REDUCE(OP_PROD, longlong, long long);
+    TEST_SHMEM_REDUCE(OP_PROD, ptrdiff, ptrdiff_t);
+    TEST_SHMEM_REDUCE(OP_PROD, uchar, unsigned char);
+    TEST_SHMEM_REDUCE(OP_PROD, ushort, unsigned short);
+    TEST_SHMEM_REDUCE(OP_PROD, uint, unsigned int);
+    TEST_SHMEM_REDUCE(OP_PROD, ulong, unsigned long);
+    TEST_SHMEM_REDUCE(OP_PROD, ulonglong, unsigned long long);
+    TEST_SHMEM_REDUCE(OP_PROD, int8, int8_t);
+    TEST_SHMEM_REDUCE(OP_PROD, int16, int16_t);
+    TEST_SHMEM_REDUCE(OP_PROD, int32, int32_t);
+    TEST_SHMEM_REDUCE(OP_PROD, int64, int64_t);
+    TEST_SHMEM_REDUCE(OP_PROD, uint8, uint8_t);
+    TEST_SHMEM_REDUCE(OP_PROD, uint16, uint16_t);
+    TEST_SHMEM_REDUCE(OP_PROD, uint32, uint32_t);
+    TEST_SHMEM_REDUCE(OP_PROD, uint64, uint64_t);
+    TEST_SHMEM_REDUCE(OP_PROD, size, size_t);
+    TEST_SHMEM_REDUCE(OP_PROD, float, float);
+    TEST_SHMEM_REDUCE(OP_PROD, double, double);
+    TEST_SHMEM_REDUCE(OP_PROD, longdouble, long double);
+    TEST_SHMEM_REDUCE(OP_PROD, complexd, double _Complex);
+    TEST_SHMEM_REDUCE(OP_PROD, complexf, float _Complex);
+
+    fprintf(stdout, "Test passed with ret = %d\n", rc);
+  
+    shmem_finalize();
+    return rc;
+}

--- a/test/unit/cxx_test_shmem_test.cpp
+++ b/test/unit/cxx_test_shmem_test.cpp
@@ -56,11 +56,9 @@ int main(int argc, char* argv[]) {
   shmem_init();
 
   int rc = EXIT_SUCCESS;
-  TEST_SHMEM_TEST(short, short);
   TEST_SHMEM_TEST(int, int);
   TEST_SHMEM_TEST(long, long);
   TEST_SHMEM_TEST(long long, longlong);
-  TEST_SHMEM_TEST(unsigned short, ushort);
   TEST_SHMEM_TEST(unsigned int, uint);
   TEST_SHMEM_TEST(unsigned long, ulong);
   TEST_SHMEM_TEST(unsigned long long, ulonglong);

--- a/test/unit/cxx_test_shmem_wait_until.cpp
+++ b/test/unit/cxx_test_shmem_wait_until.cpp
@@ -56,11 +56,9 @@ int main(int argc, char* argv[]) {
   shmem_init();
 
   int rc = EXIT_SUCCESS;
-  TEST_SHMEM_WAIT_UNTIL(short, short);
   TEST_SHMEM_WAIT_UNTIL(int, int);
   TEST_SHMEM_WAIT_UNTIL(long, long);
   TEST_SHMEM_WAIT_UNTIL(long long, longlong);
-  TEST_SHMEM_WAIT_UNTIL(unsigned short, ushort);
   TEST_SHMEM_WAIT_UNTIL(unsigned int, uint);
   TEST_SHMEM_WAIT_UNTIL(unsigned long, ulong);
   TEST_SHMEM_WAIT_UNTIL(unsigned long long, ulonglong);

--- a/test/unit/fadd_nbi.c
+++ b/test/unit/fadd_nbi.c
@@ -28,7 +28,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <shmem.h>
-#include <shmemx.h>
+#include "tests_sos/wtime.h"
 
 long ctr = 0;
 
@@ -48,14 +48,14 @@ int main(void) {
 
     ctr = 0;
     shmem_barrier_all();
-    t = shmemx_wtime();
+    t = tests_sos_wtime();
 
     for (i = 0; i < npes; i++) {
         out[i] = shmem_long_atomic_fetch_add(&ctr, 1, i);
     }
 
     shmem_barrier_all();
-    t = shmemx_wtime() - t;
+    t = tests_sos_wtime() - t;
 
     if (me == 0) printf("fetch_add     %10.2fus\n", t*1000000);
 
@@ -70,14 +70,14 @@ int main(void) {
 
     ctr = 0;
     shmem_barrier_all();
-    t = shmemx_wtime();
+    t = tests_sos_wtime();
 
     for (i = 0; i < npes; i++) {
         shmem_long_atomic_fetch_add_nbi(&out[i], &ctr, 1, i);
     }
 
     shmem_barrier_all();
-    t = shmemx_wtime() - t;
+    t = tests_sos_wtime() - t;
 
     if (me == 0) printf("fetch_add_nbi %10.2fus\n", t*1000000);
 

--- a/test/unit/lfinc.c
+++ b/test/unit/lfinc.c
@@ -39,17 +39,9 @@
 #include <sys/time.h>
 
 #include <shmem.h>
-#include <shmemx.h>
+#include "tests_sos/wtime.h"
 
 #define LOOPS 25000
-
-#ifndef HAVE_SHMEMX_WTIME
-static double shmemx_wtime(void) {
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
-    return (double) tv.tv_sec + (double) tv.tv_usec / 1000000.0;
-}
-#endif /* HAVE_SHMEMX_WTIME */
 
 int Verbose;
 double elapsed;
@@ -90,11 +82,11 @@ int main( int argc, char *argv[])
     shmem_barrier_all();
 
     neighbor = (my_pe + 1) % npes;
-    start_time = shmemx_wtime();
+    start_time = tests_sos_wtime();
     for(j=0,elapsed=0.0; j < loops; j++) {
-        start_time = shmemx_wtime();
+        start_time = tests_sos_wtime();
         lval = shmem_long_atomic_fetch_inc( (void*)&data[1], neighbor );
-        elapsed += shmemx_wtime() - start_time;
+        elapsed += tests_sos_wtime() - start_time;
         if (lval != (long) j) {
             fprintf(stderr,"[%d] Test: FAIL previous val %ld != %d Exit.\n",
                     my_pe, lval, j);

--- a/test/unit/nop_collectives.c
+++ b/test/unit/nop_collectives.c
@@ -117,19 +117,19 @@ int main(void) {
 #ifdef ENABLE_DEPRECATED_TESTS
     shmem_int_and_to_all(NULL, NULL, 0, 0, 0, npes, pwrk, reduce_psync);
 #else
-    shmem_int_and_reduce(SHMEM_TEAM_WORLD, NULL, NULL, 0);
+    shmem_uint_and_reduce(SHMEM_TEAM_WORLD, NULL, NULL, 0);
 #endif
     shmem_barrier_all();
 #ifdef ENABLE_DEPRECATED_TESTS
     shmem_int_or_to_all(NULL, NULL, 0, 0, 0, npes, pwrk, reduce_psync);
 #else
-    shmem_int_or_reduce(SHMEM_TEAM_WORLD, NULL, NULL, 0);
+    shmem_uint_or_reduce(SHMEM_TEAM_WORLD, NULL, NULL, 0);
 #endif
     shmem_barrier_all();
 #ifdef ENABLE_DEPRECATED_TESTS
     shmem_int_xor_to_all(NULL, NULL, 0, 0, 0, npes, pwrk, reduce_psync);
 #else
-    shmem_int_xor_reduce(SHMEM_TEAM_WORLD, NULL, NULL, 0);
+    shmem_uint_xor_reduce(SHMEM_TEAM_WORLD, NULL, NULL, 0);
 #endif
     shmem_barrier_all();
 #ifdef ENABLE_DEPRECATED_TESTS

--- a/test/unit/self_collectives.c
+++ b/test/unit/self_collectives.c
@@ -47,6 +47,7 @@ int pwrk[SHMEM_REDUCE_MIN_WRKDATA_SIZE];
     } while (0)
 
 int in, out;
+unsigned int uin, uout;
 int32_t in_32, out_32;
 int64_t in_64, out_64;
 
@@ -165,9 +166,10 @@ int main(void) {
     shmem_int_and_to_all(&in, &out, 1, me, 0, 1, pwrk, reduce_psync);
     CHECK("shmem_int_and_to_all", in, out);
 #else
+    uin = (unsigned) me; uout = -1U;
     if (new_team != SHMEM_TEAM_INVALID)
-        shmem_int_and_reduce(new_team, &in, &out, 1);
-    CHECK("shmem_int_and_reduce", in, out);
+        shmem_uint_and_reduce(new_team, &uin, &uout, 1);
+    CHECK("shmem_uint_and_reduce", uin, uout);
 #endif
     shmem_barrier_all();
 
@@ -176,9 +178,10 @@ int main(void) {
     shmem_int_or_to_all(&in, &out, 1, me, 0, 1, pwrk, reduce_psync);
     CHECK("shmem_int_or_to_all", in, out);
 #else
+    uin = (unsigned) me; uout = -1U;
     if (new_team != SHMEM_TEAM_INVALID)
-        shmem_int_or_reduce(new_team, &in, &out, 1);
-    CHECK("shmem_int_or_reduce", in, out);
+        shmem_uint_or_reduce(new_team, &uin, &uout, 1);
+    CHECK("shmem_uint_or_reduce", uin, uout);
 #endif
     shmem_barrier_all();
 
@@ -187,9 +190,10 @@ int main(void) {
     shmem_int_xor_to_all(&in, &out, 1, me, 0, 1, pwrk, reduce_psync);
     CHECK("shmem_int_xor_to_all", in, out);
 #else
+    uin = (unsigned) me; uout = -1U;
     if (new_team != SHMEM_TEAM_INVALID)
-        shmem_int_xor_reduce(new_team, &in, &out, 1);
-    CHECK("shmem_int_xor_reduce", in, out);
+        shmem_uint_xor_reduce(new_team, &uin, &uout, 1);
+    CHECK("shmem_uint_xor_reduce", uin, uout);
 #endif
     shmem_barrier_all();
 

--- a/test/unit/self_collectives.c
+++ b/test/unit/self_collectives.c
@@ -166,7 +166,7 @@ int main(void) {
     shmem_int_and_to_all(&in, &out, 1, me, 0, 1, pwrk, reduce_psync);
     CHECK("shmem_int_and_to_all", in, out);
 #else
-    uin = (unsigned) me; uout = -1U;
+    uin = (unsigned int) me; uout = -1U;
     if (new_team != SHMEM_TEAM_INVALID)
         shmem_uint_and_reduce(new_team, &uin, &uout, 1);
     CHECK("shmem_uint_and_reduce", uin, uout);
@@ -178,7 +178,7 @@ int main(void) {
     shmem_int_or_to_all(&in, &out, 1, me, 0, 1, pwrk, reduce_psync);
     CHECK("shmem_int_or_to_all", in, out);
 #else
-    uin = (unsigned) me; uout = -1U;
+    uin = (unsigned int) me; uout = -1U;
     if (new_team != SHMEM_TEAM_INVALID)
         shmem_uint_or_reduce(new_team, &uin, &uout, 1);
     CHECK("shmem_uint_or_reduce", uin, uout);
@@ -190,7 +190,7 @@ int main(void) {
     shmem_int_xor_to_all(&in, &out, 1, me, 0, 1, pwrk, reduce_psync);
     CHECK("shmem_int_xor_to_all", in, out);
 #else
-    uin = (unsigned) me; uout = -1U;
+    uin = (unsigned int) me; uout = -1U;
     if (new_team != SHMEM_TEAM_INVALID)
         shmem_uint_xor_reduce(new_team, &uin, &uout, 1);
     CHECK("shmem_uint_xor_reduce", uin, uout);

--- a/test/unit/shmem_team_max.c
+++ b/test/unit/shmem_team_max.c
@@ -55,7 +55,7 @@ int main(void)
 #else
         shmem_team_sync(SHMEM_TEAM_WORLD);
 #endif
-        shmem_int_and_reduce(SHMEM_TEAM_WORLD, &dest_ret, &ret, 1);
+        shmem_int_sum_reduce(SHMEM_TEAM_WORLD, &dest_ret, &ret, 1);
 
         /* If success was not global, free a team and retry */
         if (dest_ret != 0) {

--- a/test/unit/spam.c
+++ b/test/unit/spam.c
@@ -50,7 +50,7 @@
 #include <assert.h>
 
 #include <shmem.h>
-#include <shmemx.h>
+#include "tests_sos/wtime.h"
 
 void one2many_put(int *dst, int *src, int Elems, int me, int npe, int laps);
 void many2one_get(int *dst, int *src, int Elems, int me, int npe, int laps);
@@ -64,10 +64,6 @@ void fcollect(int *dst, int *src, int Elems, int me, int npes, int laps);
 
 static int atoi_scaled(char *s);
 static void usage(char *pgm);
-
-#ifndef HAVE_SHMEMX_WTIME
-static double shmemx_wtime(void);
-#endif
 
 int Verbose=1;
 int All2=0;
@@ -212,12 +208,12 @@ one2many_put(int *target, int *src, int elements, int me, int npes, int loops)
     shmem_barrier_all();
 
     if (me == 0) {
-        start_time = shmemx_wtime();
+        start_time = tests_sos_wtime();
         for(i = 0; i < loops; i++) {
             for(pe = 1; pe < npes; pe++)
                 shmem_int_put(target, src, elements, pe);
         }
-        elapsed_time = shmemx_wtime() - start_time;
+        elapsed_time = tests_sos_wtime() - start_time;
 
         if (Verbose) {
             printf("%7.3f secs\n", elapsed_time);
@@ -246,12 +242,12 @@ many2one_get(int *target, int *src, int elements, int me, int npes, int loops)
     shmem_barrier_all();
 
     if (me == 0) {
-        start_time = shmemx_wtime();
+        start_time = tests_sos_wtime();
         for(i = 0; i < loops; i++) {
             for(pe = 1; pe < npes; pe++)
                 shmem_int_get(target, src, elements, pe);
         }
-        elapsed_time = shmemx_wtime() - start_time;
+        elapsed_time = tests_sos_wtime() - start_time;
 
         if (Verbose) {
             printf("%7.3f secs\n", elapsed_time);
@@ -278,12 +274,12 @@ all2all_get(int *target, int *src, int elements, int me, int npes, int loops)
     }
     shmem_barrier_all();
 
-    start_time = shmemx_wtime();
+    start_time = tests_sos_wtime();
     for(i = 0; i < loops; i++) {
         for(pe = 0; pe < npes; pe++)
             shmem_int_get(target, src, elements, pe);
     }
-    elapsed_time = shmemx_wtime() - start_time;
+    elapsed_time = tests_sos_wtime() - start_time;
 
     if (me==0 && Verbose) {
         printf("%7.3f secs\n", elapsed_time);
@@ -312,12 +308,12 @@ all2all_put(int *target, int *src, int elements, int me, int npes, int loops)
 
     shmem_barrier_all();
 
-    start_time = shmemx_wtime();
+    start_time = tests_sos_wtime();
     for(i = 0; i < loops; i++) {
         for(pe = 0; pe < npes; pe++)
             shmem_int_put(target, src, elements, pe);
     }
-    elapsed_time = shmemx_wtime() - start_time;
+    elapsed_time = tests_sos_wtime() - start_time;
 
     if (me==0 && Verbose) {
         printf("%7.3f secs\n", elapsed_time);
@@ -347,10 +343,10 @@ neighbor_put(int *target, int *src, int elements, int me, int npes, int loops)
 
     neighbor_pe = (me + 1) % npes;
 
-    start_time = shmemx_wtime();
+    start_time = tests_sos_wtime();
     for(i = 0; i < loops; i++)
         shmem_int_put(target, src, elements, neighbor_pe);
-    elapsed_time = shmemx_wtime() - start_time;
+    elapsed_time = tests_sos_wtime() - start_time;
 
     if (me==0 && Verbose) {
         printf("%7.3f secs\n", elapsed_time);
@@ -379,10 +375,10 @@ neighbor_get(int *target, int *src, int elements, int me, int npes, int loops)
 
     neighbor_pe = (me + 1) % npes;
 
-    start_time = shmemx_wtime();
+    start_time = tests_sos_wtime();
     for(i = 0; i < loops; i++)
         shmem_int_get(target, src, elements, neighbor_pe);
-    elapsed_time = shmemx_wtime() - start_time;
+    elapsed_time = tests_sos_wtime() - start_time;
 
     if (me==0 && Verbose) {
         printf("%7.3f secs\n", elapsed_time);
@@ -417,12 +413,12 @@ bcast(int *target, int *src, int elements, int me, int npes, int loops)
 
     shmem_barrier_all();
 
-    start_time = shmemx_wtime();
+    start_time = tests_sos_wtime();
     for(i = 0; i < loops; i++) {
         ps = (i & 1) ? pSync1 : pSync;
         shmem_broadcast32( target, src, elements, 0, 0, 0, npes, ps );
     }
-    elapsed_time = shmemx_wtime() - start_time;
+    elapsed_time = tests_sos_wtime() - start_time;
 
     if (me==0 && Verbose) {
         printf("%7.3f secs\n", elapsed_time);
@@ -459,12 +455,12 @@ collect(int *target, int *src, int elements, int me, int npes, int loops)
 
     shmem_barrier_all();
 
-    start_time = shmemx_wtime();
+    start_time = tests_sos_wtime();
     for(i = 0; i < loops; i++) {
         ps = (i & 1) ? pSync1 : pSync;
         shmem_collect32( target, src, elements, 0, 0, npes, ps );
     }
-    elapsed_time = shmemx_wtime() - start_time;
+    elapsed_time = tests_sos_wtime() - start_time;
 
     if (me==0 && Verbose) {
         printf("%7.3f secs\n", elapsed_time);
@@ -504,12 +500,12 @@ fcollect(int *target, int *src, int elements, int me, int npes, int loops)
 
     shmem_barrier_all();
 
-    start_time = shmemx_wtime();
+    start_time = tests_sos_wtime();
     for(i = 0; i < loops; i++) {
         ps = &pSync[(i&1)];
         shmem_fcollect32( target, src, elements, 0, 0, npes, ps );
     }
-    elapsed_time = shmemx_wtime() - start_time;
+    elapsed_time = tests_sos_wtime() - start_time;
 
     if (me==0 && Verbose) {
         printf("%7.3f secs\n", elapsed_time);
@@ -563,20 +559,3 @@ usage(char *pgm)
         "    -h             this text.\n",
         pgm,DFLT_LOOPS, N_ELEMENTS);
 }
-
-
-#ifndef HAVE_SHMEMX_WTIME
-
-static double
-shmemx_wtime(void)
-{
-    double wtime;
-    struct timeval tv;
-
-    gettimeofday(&tv, NULL);
-    wtime = tv.tv_sec;
-    wtime += (double)tv.tv_usec / 1000000.0;
-    return wtime;
-}
-
-#endif /* HAVE_SHMEMX_WTIME */

--- a/test/unit/to_all.c
+++ b/test/unit/to_all.c
@@ -94,6 +94,7 @@ double src4[N], dst4[N];
 long double src5[N], dst5[N];
 long long src6[N], dst6[N];
 
+/* bitwise reduction types */
 unsigned short src7[N], dst7[N];
 unsigned int src8[N], dst8[N];
 unsigned long src9[N], dst9[N];

--- a/test/unit/to_all.c
+++ b/test/unit/to_all.c
@@ -69,10 +69,10 @@
 #define Vprintf if (Verbose > 1) printf
 
 int sum_reduce(int me, int npes);
-int and_reduce(int me, int npes);
 int min_reduce(int me, int npes);
 int max_reduce(int me, int npes);
 int prod_reduce(int me, int npes);
+int and_reduce(int me, int npes);
 int or_reduce(int me, int npes);
 int xor_reduce(int me, int npes);
 
@@ -93,6 +93,11 @@ float src3[N], dst3[N];
 double src4[N], dst4[N];
 long double src5[N], dst5[N];
 long long src6[N], dst6[N];
+
+unsigned short src7[N], dst7[N];
+unsigned int src8[N], dst8[N];
+unsigned long src9[N], dst9[N];
+unsigned long long src10[N], dst10[N];
 
 short expected_result0;
 int expected_result1;
@@ -384,69 +389,6 @@ sum_reduce(int me, int npes)
 
 
 int
-and_reduce(int me, int num_pes)
-{
-    int i, pass=0;
-
-    memset(ok,0,sizeof(ok));
-
-    for (i = 0; i < N; i++) {
-        src0[i] = src1[i] = src2[i] = src6[i] = me;
-        dst0[i] = dst1[i] = dst2[i] = dst6[i] = -9;
-    }
-
-    shmem_barrier_all();
-
-    shmem_short_and_reduce(   SHMEM_TEAM_WORLD, dst0, src0, N);
-    shmem_int_and_reduce(     SHMEM_TEAM_WORLD, dst1, src1, N);
-    shmem_long_and_reduce(    SHMEM_TEAM_WORLD, dst2, src2, N);
-    shmem_longlong_and_reduce(SHMEM_TEAM_WORLD, dst6, src6, N);
-
-    if (me==0) {
-      for (i = 0; i < N; i++) {
-          if(dst0[i] != 0) ok[0] = 1;
-          if(dst1[i] != 0) ok[1] = 1;
-          if(dst2[i] != 0) ok[2] = 1;
-          if(dst6[i] != 0) ok[3] = 1;
-      }
-
-      if(ok[0]==1){
-        printf("Reduction operation shmem_short_and_reduce: Failed\n");
-      }
-      else{
-        Vprintf("Reduction operation shmem_short_and_reduce: Passed\n");
-        pass++;
-        }
-        if(ok[1]==1){
-        printf("Reduction operation shmem_int_and_reduce: Failed\n");
-        }
-      else{
-        Vprintf("Reduction operation shmem_int_and_reduce: Passed\n");
-        pass++;
-        }
-        if(ok[2]==1){
-        printf("Reduction operation shmem_long_and_reduce: Failed\n");
-        }
-      else{
-        Vprintf("Reduction operation shmem_long_and_reduce: Passed\n");
-        pass++;
-        }
-        if(ok[3]==1){
-        printf("Reduction operation shmem_longlong_and_reduce: Failed\n");
-        }
-      else{
-        Vprintf("Reduction operation shmem_longlong_and_reduce: Passed\n");
-        pass++;
-        }
-      Vprintf("\n"); fflush(stdout);
-    }
-    if (Serialize) shmem_barrier_all();
-
-    return (pass == 4 ? 1 : 0);
-}
-
-
-int
 prod_reduce(int me, int npes)
 {
     int i, pass=0;
@@ -594,6 +536,69 @@ prod_reduce(int me, int npes)
 
 
 int
+and_reduce(int me, int num_pes)
+{
+    int i, pass=0;
+
+    memset(ok,0,sizeof(ok));
+
+    for (i = 0; i < N; i++) {
+        src0[i] = src1[i] = src2[i] = src6[i] = me;
+        dst0[i] = dst1[i] = dst2[i] = dst6[i] = -9;
+    }
+
+    shmem_barrier_all();
+
+    shmem_ushort_and_reduce(   SHMEM_TEAM_WORLD, dst7,  src7, N);
+    shmem_uint_and_reduce(     SHMEM_TEAM_WORLD, dst8,  src8, N);
+    shmem_ulong_and_reduce(    SHMEM_TEAM_WORLD, dst9,  src9, N);
+    shmem_ulonglong_and_reduce(SHMEM_TEAM_WORLD, dst10, src10, N);
+
+    if (me==0) {
+      for (i = 0; i < N; i++) {
+          if(dst7[i]  != 0) ok[0] = 1;
+          if(dst8[i]  != 0) ok[1] = 1;
+          if(dst9[i]  != 0) ok[2] = 1;
+          if(dst10[i] != 0) ok[3] = 1;
+      }
+
+      if(ok[0]==1){
+        printf("Reduction operation shmem_ushort_and_reduce: Failed\n");
+      }
+      else{
+        Vprintf("Reduction operation shmem_ushort_and_reduce: Passed\n");
+        pass++;
+        }
+        if(ok[1]==1){
+        printf("Reduction operation shmem_uint_and_reduce: Failed\n");
+        }
+      else{
+        Vprintf("Reduction operation shmem_uint_and_reduce: Passed\n");
+        pass++;
+        }
+        if(ok[2]==1){
+        printf("Reduction operation shmem_ulong_and_reduce: Failed\n");
+        }
+      else{
+        Vprintf("Reduction operation shmem_ulong_and_reduce: Passed\n");
+        pass++;
+        }
+        if(ok[3]==1){
+        printf("Reduction operation shmem_ulonglong_and_reduce: Failed\n");
+        }
+      else{
+        Vprintf("Reduction operation shmem_ulonglong_and_reduce: Passed\n");
+        pass++;
+        }
+      Vprintf("\n"); fflush(stdout);
+    }
+    if (Serialize) shmem_barrier_all();
+
+    return (pass == 4 ? 1 : 0);
+}
+
+
+int
 or_reduce(int me, int npes)
 {
     int i, pass=0;
@@ -601,55 +606,55 @@ or_reduce(int me, int npes)
     memset(ok,0,sizeof(ok));
 
     for (i = 0; i < N; i++) {
-      src0[i] = src1[i] = src2[i] = src6[i] = (me + 1)%4;
-      dst0[i] = -9;
-      dst1[i] = -9;
-      dst2[i] = -9;
-      dst6[i] = -9;
+      src7[i]  = src8[i] = src9[i] = src10[i] = (me + 1)%4;
+      dst7[i]  = -9;
+      dst8[i]  = -9;
+      dst9[i]  = -9;
+      dst10[i] = -9;
     }
 
     shmem_barrier_all();
 
-    shmem_short_or_reduce(   SHMEM_TEAM_WORLD, dst0, src0, N);
-    shmem_int_or_reduce(     SHMEM_TEAM_WORLD, dst1, src1, N);
-    shmem_long_or_reduce(    SHMEM_TEAM_WORLD, dst2, src2, N);
-    shmem_longlong_or_reduce(SHMEM_TEAM_WORLD, dst6, src6, N);
+    shmem_ushort_or_reduce(   SHMEM_TEAM_WORLD, dst7,  src7, N);
+    shmem_uint_or_reduce(     SHMEM_TEAM_WORLD, dst8,  src8, N);
+    shmem_ulong_or_reduce(    SHMEM_TEAM_WORLD, dst9,  src9, N);
+    shmem_ulonglong_or_reduce(SHMEM_TEAM_WORLD, dst10, src10, N);
 
     if (me==0) {
         for (i = 0; i < N; i++) {
             int expected = (npes == 1) ? 1 : 3;
 
-            if(dst0[i] != expected) ok[0] = 1;
-            if(dst1[i] != expected) ok[1] = 1;
-            if(dst2[i] != expected) ok[2] = 1;
-            if(dst6[i] != expected) ok[6] = 1;
+            if(dst7[i]  != expected) ok[0] = 1;
+            if(dst8[i]  != expected) ok[1] = 1;
+            if(dst9[i]  != expected) ok[2] = 1;
+            if(dst10[i] != expected) ok[6] = 1;
         }
 
         if(ok[0]==1)
-            printf("Reduction operation shmem_short_or_reduce: Failed\n");
+            printf("Reduction operation shmem_ushort_or_reduce: Failed\n");
         else {
-            Vprintf("Reduction operation shmem_short_or_reduce: Passed\n");
+            Vprintf("Reduction operation shmem_ushort_or_reduce: Passed\n");
             pass++;
         }
 
         if(ok[1]==1)
-            printf("Reduction operation shmem_int_or_reduce: Failed\n");
+            printf("Reduction operation shmem_uint_or_reduce: Failed\n");
         else {
-            Vprintf("Reduction operation shmem_int_or_reduce: Passed\n");
+            Vprintf("Reduction operation shmem_uint_or_reduce: Passed\n");
             pass++;
         }
 
         if(ok[2]==1)
-            printf("Reduction operation shmem_long_or_reduce: Failed\n");
+            printf("Reduction operation shmem_ulong_or_reduce: Failed\n");
         else {
-            Vprintf("Reduction operation shmem_long_or_reduce: Passed\n");
+            Vprintf("Reduction operation shmem_ulong_or_reduce: Passed\n");
             pass++;
         }
 
         if(ok[6]==1)
-            printf("Reduction operation shmem_longlong_or_reduce: Failed\n");
+            printf("Reduction operation shmem_ulonglong_or_reduce: Failed\n");
         else {
-            Vprintf("Reduction operation shmem_longlong_or_reduce: Passed\n");
+            Vprintf("Reduction operation shmem_ulonglong_or_reduce: Passed\n");
             pass++;
         }
         Vprintf("\n");
@@ -669,53 +674,53 @@ xor_reduce(int me, int npes)
     memset(ok,0,sizeof(ok));
 
     for (i = 0; i < N; i++) {
-        src0[i] = src1[i] = src2[i] = src6[i] = me%2;
-        dst0[i] = -9;
-        dst1[i] = -9;
-        dst2[i] = -9;
-        dst6[i] = -9;
+        src7[i]  = src8[i] = src9[i] = src10[i] = me%2;
+        dst7[i]  = -9;
+        dst8[i]  = -9;
+        dst9[i]  = -9;
+        dst10[i] = -9;
     }
 
     shmem_barrier_all();
 
-    shmem_short_xor_reduce(   SHMEM_TEAM_WORLD, dst0, src0, N);
-    shmem_int_xor_reduce(     SHMEM_TEAM_WORLD, dst1, src1, N);
-    shmem_long_xor_reduce(    SHMEM_TEAM_WORLD, dst2, src2, N);
-    shmem_longlong_xor_reduce(SHMEM_TEAM_WORLD, dst6, src6, N);
+    shmem_ushort_xor_reduce(   SHMEM_TEAM_WORLD, dst7,  src7, N);
+    shmem_uint_xor_reduce(     SHMEM_TEAM_WORLD, dst8,  src8, N);
+    shmem_ulong_xor_reduce(    SHMEM_TEAM_WORLD, dst9,  src9, N);
+    shmem_ulonglong_xor_reduce(SHMEM_TEAM_WORLD, dst10, src10, N);
 
     if (me==0) {
       for (i = 0; i < N; i++) {
-          if(dst0[i] != expected_result) ok[0] = 1;
-          if(dst1[i] != expected_result) ok[1] = 1;
-          if(dst2[i] != expected_result) ok[2] = 1;
-          if(dst6[i] != expected_result) ok[6] = 1;
+          if(dst7[i]  != expected_result) ok[0] = 1;
+          if(dst8[i]  != expected_result) ok[1] = 1;
+          if(dst9[i]  != expected_result) ok[2] = 1;
+          if(dst10[i] != expected_result) ok[6] = 1;
       }
 
       if(ok[0]==1)
-          printf("Reduction operation shmem_short_xor_reduce: Failed\n");
+          printf("Reduction operation shmem_ushort_xor_reduce: Failed\n");
       else {
-          Vprintf("Reduction operation shmem_short_xor_reduce: Passed\n");
+          Vprintf("Reduction operation shmem_ushort_xor_reduce: Passed\n");
           pass++;
       }
 
       if(ok[1]==1)
-          printf("Reduction operation shmem_int_xor_reduce: Failed\n");
+          printf("Reduction operation shmem_uint_xor_reduce: Failed\n");
        else {
-          Vprintf("Reduction operation shmem_int_xor_reduce: Passed\n");
+          Vprintf("Reduction operation shmem_uint_xor_reduce: Passed\n");
           pass++;
       }
 
        if(ok[2]==1)
-          printf("Reduction operation shmem_long_xor_reduce: Failed\n");
+          printf("Reduction operation shmem_ulong_xor_reduce: Failed\n");
         else {
-          Vprintf("Reduction operation shmem_long_xor_reduce: Passed\n");
+          Vprintf("Reduction operation shmem_ulong_xor_reduce: Passed\n");
           pass++;
       }
 
         if(ok[6]==1)
-          printf("Reduction operation shmem_longlong_xor_reduce: Failed\n");
+          printf("Reduction operation shmem_ulonglong_xor_reduce: Failed\n");
         else {
-          Vprintf("Reduction operation shmem_longlong_xor_reduce: Passed\n");
+          Vprintf("Reduction operation shmem_ulonglong_xor_reduce: Passed\n");
           pass++;
       }
 


### PR DESCRIPTION
This incorporates SOS changes from the following PRs:

* https://github.com/Sandia-OpenSHMEM/SOS/pull/1098 - removes unsupported signed reductions tests for v1.5
* https://github.com/Sandia-OpenSHMEM/SOS/pull/1096 - provides a fallback when `shmemx_wtime` is not available
* https://github.com/Sandia-OpenSHMEM/SOS/pull/1095 - adds missing reduction types for C++ templates

After merging, we can close https://github.com/openshmem-org/tests-sos/pull/26
