### PR TITLE
automake: make internal include paths to relative

### DIFF
--- a/test/apps/Makefile.am
+++ b/test/apps/Makefile.am
@@ -45,7 +45,7 @@ bin_PROGRAMS = $(check_PROGRAMS)
 AM_CPPFLAGS = -I$(top_srcdir)/test/include
 LDADD =
 else
-AM_CPPFLAGS = -I$(top_builddir)/mpp -I$(top_srcdir)/mpp -I$(top_srcdir)/test/include
+AM_CPPFLAGS = -I$(top_builddir)/mpp -I$(top_srcdir)/mpp -I../include
 LDADD = $(top_builddir)/src/libsma.la
 endif
 

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -199,7 +199,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/test/include
 AM_FCFLAGS =
 LDADD =
 else
-AM_CPPFLAGS = -I$(top_builddir)/mpp -I$(top_srcdir)/mpp -I$(top_srcdir)/test/include
+AM_CPPFLAGS = -I$(top_builddir)/mpp -I$(top_srcdir)/mpp -I../include
 AM_FCFLAGS = -I$(top_builddir)/mpp
 LDADD = $(top_builddir)/src/libsma.la
 endif


### PR DESCRIPTION
This change supports tests-sos as a submodule to SOS (see https://github.com/Sandia-OpenSHMEM/SOS/pull/1106).  This change is only strictly needed to support the RPM build with tests-sos as a submodule... but also allows us to remove "test" symlink file in SOS PR #1106.