### PR TITLE
automake: revert relative include path to explicit

### DIFF
--- a/test/apps/Makefile.am
+++ b/test/apps/Makefile.am
@@ -45,7 +45,7 @@ bin_PROGRAMS = $(check_PROGRAMS)
 AM_CPPFLAGS = -I$(top_srcdir)/test/include
 LDADD =
 else
-AM_CPPFLAGS = -I$(top_builddir)/mpp -I$(top_srcdir)/mpp -I../include
+AM_CPPFLAGS = -I$(top_builddir)/mpp -I$(top_srcdir)/mpp -I$(top_srcdir)/modules/tests-sos/include
 LDADD = $(top_builddir)/src/libsma.la
 endif
 

--- a/test/shmemx/Makefile.am
+++ b/test/shmemx/Makefile.am
@@ -64,7 +64,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/test/include
 AM_FCFLAGS =
 LDADD =
 else
-AM_CPPFLAGS = -I$(top_builddir)/mpp -I$(top_srcdir)/mpp -I../include
+AM_CPPFLAGS = -I$(top_builddir)/mpp -I$(top_srcdir)/mpp -I$(top_srcdir)/modules/tests-sos/include
 AM_FCFLAGS = -I$(top_builddir)/mpp
 LDADD = $(top_builddir)/src/libsma.la
 endif

--- a/test/spec-example/Makefile.am
+++ b/test/spec-example/Makefile.am
@@ -58,7 +58,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/test/include
 AM_FCFLAGS =
 LDADD =
 else
-AM_CPPFLAGS = -I$(top_builddir)/mpp -I$(top_srcdir)/mpp -I../include
+AM_CPPFLAGS = -I$(top_builddir)/mpp -I$(top_srcdir)/mpp -I$(top_srcdir)/modules/tests-sos/include
 AM_FCFLAGS = -I$(top_builddir)/mpp
 LDADD = $(top_builddir)/src/libsma.la
 endif

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -199,7 +199,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/test/include
 AM_FCFLAGS =
 LDADD =
 else
-AM_CPPFLAGS = -I$(top_builddir)/mpp -I$(top_srcdir)/mpp -I../include
+AM_CPPFLAGS = -I$(top_builddir)/mpp -I$(top_srcdir)/mpp -I$(top_srcdir)/modules/tests-sos/include
 AM_FCFLAGS = -I$(top_builddir)/mpp
 LDADD = $(top_builddir)/src/libsma.la
 endif


### PR DESCRIPTION
My apologies for the churn here, #32 was not quite right for https://github.com/Sandia-OpenSHMEM/SOS/pull/1106

If `EXTERNAL_TESTS` is not defined, it's better to use the full path from `$top_srcdir` so that both the RPM and building within an isolated `$top_builddir` works.  PR #32 only works for building from `$top_srcdir`..