### PR TITLE
automake: fix typo from explicit include path fix

### DIFF
--- a/test/apps/Makefile.am
+++ b/test/apps/Makefile.am
@@ -45,7 +45,7 @@ bin_PROGRAMS = $(check_PROGRAMS)
 AM_CPPFLAGS = -I$(top_srcdir)/test/include
 LDADD =
 else
-AM_CPPFLAGS = -I$(top_builddir)/mpp -I$(top_srcdir)/mpp -I$(top_srcdir)/modules/tests-sos/include
+AM_CPPFLAGS = -I$(top_builddir)/mpp -I$(top_srcdir)/mpp -I$(top_srcdir)/modules/tests-sos/test/include
 LDADD = $(top_builddir)/src/libsma.la
 endif
 

--- a/test/shmemx/Makefile.am
+++ b/test/shmemx/Makefile.am
@@ -64,7 +64,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/test/include
 AM_FCFLAGS =
 LDADD =
 else
-AM_CPPFLAGS = -I$(top_builddir)/mpp -I$(top_srcdir)/mpp -I$(top_srcdir)/modules/tests-sos/include
+AM_CPPFLAGS = -I$(top_builddir)/mpp -I$(top_srcdir)/mpp -I$(top_srcdir)/modules/tests-sos/test/include
 AM_FCFLAGS = -I$(top_builddir)/mpp
 LDADD = $(top_builddir)/src/libsma.la
 endif

--- a/test/spec-example/Makefile.am
+++ b/test/spec-example/Makefile.am
@@ -58,7 +58,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/test/include
 AM_FCFLAGS =
 LDADD =
 else
-AM_CPPFLAGS = -I$(top_builddir)/mpp -I$(top_srcdir)/mpp -I$(top_srcdir)/modules/tests-sos/include
+AM_CPPFLAGS = -I$(top_builddir)/mpp -I$(top_srcdir)/mpp -I$(top_srcdir)/modules/tests-sos/test/include
 AM_FCFLAGS = -I$(top_builddir)/mpp
 LDADD = $(top_builddir)/src/libsma.la
 endif

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -199,7 +199,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/test/include
 AM_FCFLAGS =
 LDADD =
 else
-AM_CPPFLAGS = -I$(top_builddir)/mpp -I$(top_srcdir)/mpp -I$(top_srcdir)/modules/tests-sos/include
+AM_CPPFLAGS = -I$(top_builddir)/mpp -I$(top_srcdir)/mpp -I$(top_srcdir)/modules/tests-sos/test/include
 AM_FCFLAGS = -I$(top_builddir)/mpp
 LDADD = $(top_builddir)/src/libsma.la
 endif


### PR DESCRIPTION
Sorry @philipmarshall21 @wrrobin - there was a typo in the last PR - apparently I didn't test it correctly.  It's the same motivation as #32