### PR TITLE
Add tests for IBPUT/IBGET

### DIFF
--- a/test/shmemx/Makefile.am
+++ b/test/shmemx/Makefile.am
@@ -20,6 +20,8 @@ endif
 
 if SHMEMX_TESTS
 check_PROGRAMS += \
+	c11_test_shmem_ibput \
+	c11_test_shmem_ibget \
 	perf_counter \
 	shmemx_team_node \
 	shmem_malloc_with_hints
@@ -35,8 +37,10 @@ if SHMEMX_TESTS
 check_PROGRAMS += \
 	cxx_test_shmem_g \
 	cxx_test_shmem_get \
+	cxx_test_shmem_ibget \
 	cxx_test_shmem_p \
 	cxx_test_shmem_put \
+	cxx_test_shmem_ibput \
 	cxx_test_shmem_atomic_fetch \
 	cxx_test_shmem_atomic_set \
 	cxx_test_shmem_atomic_add \
@@ -88,8 +92,10 @@ endif
 # C++ Tests
 cxx_test_shmem_g_SOURCES = cxx_test_shmem_g.cpp
 cxx_test_shmem_get_SOURCES = cxx_test_shmem_get.cpp
+cxx_test_shmem_ibget_SOURCES = cxx_test_shmem_ibget.cpp
 cxx_test_shmem_p_SOURCES = cxx_test_shmem_p.cpp
 cxx_test_shmem_put_SOURCES = cxx_test_shmem_put.cpp
+cxx_test_shmem_ibput_SOURCES = cxx_test_shmem_ibput.cpp
 cxx_test_shmem_atomic_fetch_SOURCES = cxx_test_shmem_atomic_fetch.cpp
 cxx_test_shmem_atomic_set_SOURCES = cxx_test_shmem_atomic_set.cpp
 cxx_test_shmem_atomic_add_SOURCES = cxx_test_shmem_atomic_add.cpp

--- a/test/shmemx/c11_test_shmem_ibget.c
+++ b/test/shmemx/c11_test_shmem_ibget.c
@@ -1,0 +1,126 @@
+/*
+ *  This test program is derived from a unit test created by Nick Park.
+ *  The original unit test is a work of the U.S. Government and is not subject
+ *  to copyright protection in the United States.  Foreign copyrights may
+ *  apply.
+ *
+ *  Copyright (c) 2017 Intel Corporation. All rights reserved.
+ *  This software is available to you under the BSD license below:
+ *
+ *      Redistribution and use in source and binary forms, with or
+ *      without modification, are permitted provided that the following
+ *      conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <shmem.h>
+#include <shmemx.h>
+
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+
+#define TEST_SHMEM_IBGET(USE_CTX, TYPE)                         \
+  do {                                                          \
+    static TYPE remote[10];                                     \
+    const int mype = shmem_my_pe();                             \
+    const int npes = shmem_n_pes();                             \
+    TYPE local[10];                                             \
+    for (int i = 0; i < 10; i++)                                \
+      remote[i] = (TYPE)mype;                                   \
+    shmem_barrier_all();                                        \
+                                                                \
+    if (USE_CTX)                                                \
+      shmemx_ibget(SHMEM_CTX_DEFAULT, local, remote, 1, 1, 1, 10, (mype + 1) % npes); \
+    else                                                        \
+      shmemx_ibget(local, remote, 1, 1, 1, 10, (mype + 1) % npes); \
+                                                                \
+    for (int i = 0; i < 10; i++)                                \
+      if (local[i] != (TYPE)((mype + 1) % npes)) {              \
+        printf("PE %i received incorrect value with"            \
+               "TEST_SHMEM_IBGET(%d, %s)\n", mype,              \
+               (int)(USE_CTX), #TYPE);                          \
+        rc = EXIT_FAILURE;                                      \
+      }                                                         \
+  } while (0)
+
+#else
+#define TEST_SHMEM_GET(USE_CTX, TYPE)
+
+#endif
+
+int main(int argc, char* argv[]) {
+  shmem_init();
+
+  int rc = EXIT_SUCCESS;
+  TEST_SHMEM_IBGET(0, float);
+  TEST_SHMEM_IBGET(0, double);
+  TEST_SHMEM_IBGET(0, long double);
+  TEST_SHMEM_IBGET(0, char);
+  TEST_SHMEM_IBGET(0, signed char);
+  TEST_SHMEM_IBGET(0, short);
+  TEST_SHMEM_IBGET(0, int);
+  TEST_SHMEM_IBGET(0, long);
+  TEST_SHMEM_IBGET(0, long long);
+  TEST_SHMEM_IBGET(0, unsigned char);
+  TEST_SHMEM_IBGET(0, unsigned short);
+  TEST_SHMEM_IBGET(0, unsigned int);
+  TEST_SHMEM_IBGET(0, unsigned long);
+  TEST_SHMEM_IBGET(0, unsigned long long);
+  TEST_SHMEM_IBGET(0, int8_t);
+  TEST_SHMEM_IBGET(0, int16_t);
+  TEST_SHMEM_IBGET(0, int32_t);
+  TEST_SHMEM_IBGET(0, int64_t);
+  TEST_SHMEM_IBGET(0, uint8_t);
+  TEST_SHMEM_IBGET(0, uint16_t);
+  TEST_SHMEM_IBGET(0, uint32_t);
+  TEST_SHMEM_IBGET(0, uint64_t);
+  TEST_SHMEM_IBGET(0, size_t);
+  TEST_SHMEM_IBGET(0, ptrdiff_t);
+
+  TEST_SHMEM_IBGET(1, float);
+  TEST_SHMEM_IBGET(1, double);
+  TEST_SHMEM_IBGET(1, long double);
+  TEST_SHMEM_IBGET(1, char);
+  TEST_SHMEM_IBGET(1, signed char);
+  TEST_SHMEM_IBGET(1, short);
+  TEST_SHMEM_IBGET(1, int);
+  TEST_SHMEM_IBGET(1, long);
+  TEST_SHMEM_IBGET(1, long long);
+  TEST_SHMEM_IBGET(1, unsigned char);
+  TEST_SHMEM_IBGET(1, unsigned short);
+  TEST_SHMEM_IBGET(1, unsigned int);
+  TEST_SHMEM_IBGET(1, unsigned long);
+  TEST_SHMEM_IBGET(1, unsigned long long);
+  TEST_SHMEM_IBGET(1, int8_t);
+  TEST_SHMEM_IBGET(1, int16_t);
+  TEST_SHMEM_IBGET(1, int32_t);
+  TEST_SHMEM_IBGET(1, int64_t);
+  TEST_SHMEM_IBGET(1, uint8_t);
+  TEST_SHMEM_IBGET(1, uint16_t);
+  TEST_SHMEM_IBGET(1, uint32_t);
+  TEST_SHMEM_IBGET(1, uint64_t);
+  TEST_SHMEM_IBGET(1, size_t);
+  TEST_SHMEM_IBGET(1, ptrdiff_t);
+
+  shmem_finalize();
+  return rc;
+}

--- a/test/shmemx/c11_test_shmem_ibget.c
+++ b/test/shmemx/c11_test_shmem_ibget.c
@@ -63,7 +63,7 @@
   } while (0)
 
 #else
-#define TEST_SHMEM_GET(USE_CTX, TYPE)
+#define TEST_SHMEM_IBGET(USE_CTX, TYPE)
 
 #endif
 

--- a/test/shmemx/c11_test_shmem_ibget.c
+++ b/test/shmemx/c11_test_shmem_ibget.c
@@ -4,7 +4,7 @@
  *  to copyright protection in the United States.  Foreign copyrights may
  *  apply.
  *
- *  Copyright (c) 2017 Intel Corporation. All rights reserved.
+ *  Copyright (c) 2024 Intel Corporation. All rights reserved.
  *  This software is available to you under the BSD license below:
  *
  *      Redistribution and use in source and binary forms, with or

--- a/test/shmemx/c11_test_shmem_ibput.c
+++ b/test/shmemx/c11_test_shmem_ibput.c
@@ -1,0 +1,126 @@
+/*
+ *  This test program is derived from a unit test created by Nick Park.
+ *  The original unit test is a work of the U.S. Government and is not subject
+ *  to copyright protection in the United States.  Foreign copyrights may
+ *  apply.
+ *
+ *  Copyright (c) 2017 Intel Corporation. All rights reserved.
+ *  This software is available to you under the BSD license below:
+ *
+ *      Redistribution and use in source and binary forms, with or
+ *      without modification, are permitted provided that the following
+ *      conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <shmem.h>
+#include <shmemx.h>
+
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+
+#define TEST_SHMEM_IBPUT(USE_CTX, TYPE)                         \
+  do {                                                          \
+    static TYPE remote[10];                                     \
+    const int mype = shmem_my_pe();                             \
+    const int npes = shmem_n_pes();                             \
+    TYPE local[10];                                             \
+    for (int i = 0; i < 10; i++)                                \
+      local[i] = (TYPE)mype;                                    \
+                                                                \
+    if (USE_CTX)                                                \
+      shmemx_ibput(SHMEM_CTX_DEFAULT, remote, local, 1, 1, 1, 10, (mype + 1) % npes); \
+    else                                                        \
+      shmemx_ibput(remote, local, 1, 1, 1, 10, (mype + 1) % npes); \
+                                                                \
+    shmem_barrier_all();                                        \
+    for (int i = 0; i < 10; i++)                                \
+      if (remote[i] != (TYPE)((mype + npes - 1) % npes)) {      \
+        printf("PE %i received incorrect value with "           \
+               "TEST_SHMEM_IBPUT(%d, %s)\n", mype,              \
+               (int)(USE_CTX), #TYPE);                          \
+        rc = EXIT_FAILURE;                                      \
+      }                                                         \
+  } while (0)
+
+#else
+#define TEST_SHMEM_PUT(USE_CTX, TYPE)
+
+#endif
+
+int main(int argc, char* argv[]) {
+  shmem_init();
+
+  int rc = EXIT_SUCCESS;
+  TEST_SHMEM_IBPUT(0, float);
+  TEST_SHMEM_IBPUT(0, double);
+  TEST_SHMEM_IBPUT(0, long double);
+  TEST_SHMEM_IBPUT(0, char);
+  TEST_SHMEM_IBPUT(0, signed char);
+  TEST_SHMEM_IBPUT(0, short);
+  TEST_SHMEM_IBPUT(0, int);
+  TEST_SHMEM_IBPUT(0, long);
+  TEST_SHMEM_IBPUT(0, long long);
+  TEST_SHMEM_IBPUT(0, unsigned char);
+  TEST_SHMEM_IBPUT(0, unsigned short);
+  TEST_SHMEM_IBPUT(0, unsigned int);
+  TEST_SHMEM_IBPUT(0, unsigned long);
+  TEST_SHMEM_IBPUT(0, unsigned long long);
+  TEST_SHMEM_IBPUT(0, int8_t);
+  TEST_SHMEM_IBPUT(0, int16_t);
+  TEST_SHMEM_IBPUT(0, int32_t);
+  TEST_SHMEM_IBPUT(0, int64_t);
+  TEST_SHMEM_IBPUT(0, uint8_t);
+  TEST_SHMEM_IBPUT(0, uint16_t);
+  TEST_SHMEM_IBPUT(0, uint32_t);
+  TEST_SHMEM_IBPUT(0, uint64_t);
+  TEST_SHMEM_IBPUT(0, size_t);
+  TEST_SHMEM_IBPUT(0, ptrdiff_t);
+
+  TEST_SHMEM_IBPUT(1, float);
+  TEST_SHMEM_IBPUT(1, double);
+  TEST_SHMEM_IBPUT(1, long double);
+  TEST_SHMEM_IBPUT(1, char);
+  TEST_SHMEM_IBPUT(1, signed char);
+  TEST_SHMEM_IBPUT(1, short);
+  TEST_SHMEM_IBPUT(1, int);
+  TEST_SHMEM_IBPUT(1, long);
+  TEST_SHMEM_IBPUT(1, long long);
+  TEST_SHMEM_IBPUT(1, unsigned char);
+  TEST_SHMEM_IBPUT(1, unsigned short);
+  TEST_SHMEM_IBPUT(1, unsigned int);
+  TEST_SHMEM_IBPUT(1, unsigned long);
+  TEST_SHMEM_IBPUT(1, unsigned long long);
+  TEST_SHMEM_IBPUT(1, int8_t);
+  TEST_SHMEM_IBPUT(1, int16_t);
+  TEST_SHMEM_IBPUT(1, int32_t);
+  TEST_SHMEM_IBPUT(1, int64_t);
+  TEST_SHMEM_IBPUT(1, uint8_t);
+  TEST_SHMEM_IBPUT(1, uint16_t);
+  TEST_SHMEM_IBPUT(1, uint32_t);
+  TEST_SHMEM_IBPUT(1, uint64_t);
+  TEST_SHMEM_IBPUT(1, size_t);
+  TEST_SHMEM_IBPUT(1, ptrdiff_t);
+
+  shmem_finalize();
+  return rc;
+}

--- a/test/shmemx/c11_test_shmem_ibput.c
+++ b/test/shmemx/c11_test_shmem_ibput.c
@@ -4,7 +4,7 @@
  *  to copyright protection in the United States.  Foreign copyrights may
  *  apply.
  *
- *  Copyright (c) 2017 Intel Corporation. All rights reserved.
+ *  Copyright (c) 2024 Intel Corporation. All rights reserved.
  *  This software is available to you under the BSD license below:
  *
  *      Redistribution and use in source and binary forms, with or

--- a/test/shmemx/c11_test_shmem_ibput.c
+++ b/test/shmemx/c11_test_shmem_ibput.c
@@ -63,7 +63,7 @@
   } while (0)
 
 #else
-#define TEST_SHMEM_PUT(USE_CTX, TYPE)
+#define TEST_SHMEM_IBPUT(USE_CTX, TYPE)
 
 #endif
 

--- a/test/shmemx/cxx_test_shmem_ibget.cpp
+++ b/test/shmemx/cxx_test_shmem_ibget.cpp
@@ -32,7 +32,6 @@
 
 #include <stdlib.h>
 #include <stdint.h>
-#include <stdbool.h>
 #include <stdio.h>
 #include <shmem.h>
 #include <shmemx.h>
@@ -49,11 +48,11 @@
                                                                 \
     if (USE_CTX)                                                \
       shmemx_ctx_##TYPENAME##_ibget(SHMEM_CTX_DEFAULT, local,   \
-                            remote, 1, 1, 1, 10,                \
-                            (mype + 1) % npes);                 \
+                                    remote, 1, 1, 1, 10,        \
+                                    (mype + 1) % npes);         \
     else                                                        \
       shmemx_##TYPENAME##_ibget(local, remote, 1, 1, 1, 10,     \
-                                    (mype + 1) % npes);         \
+                                (mype + 1) % npes);             \
                                                                 \
     for (int i = 0; i < 10; i++)                                \
       if (local[i] != (TYPE)((mype + 1) % npes)) {              \

--- a/test/shmemx/cxx_test_shmem_ibget.cpp
+++ b/test/shmemx/cxx_test_shmem_ibget.cpp
@@ -1,0 +1,124 @@
+/*
+ *  This test program is derived from a unit test created by Nick Park.
+ *  The original unit test is a work of the U.S. Government and is not subject
+ *  to copyright protection in the United States.  Foreign copyrights may
+ *  apply.
+ *
+ *  Copyright (c) 2024 Intel Corporation. All rights reserved.
+ *  This software is available to you under the BSD license below:
+ *
+ *      Redistribution and use in source and binary forms, with or
+ *      without modification, are permitted provided that the following
+ *      conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <shmem.h>
+#include <shmemx.h>
+
+#define TEST_SHMEM_IBGET(USE_CTX, TYPE, TYPENAME)               \
+  do {                                                          \
+    static TYPE remote[10];                                     \
+    const int mype = shmem_my_pe();                             \
+    const int npes = shmem_n_pes();                             \
+    TYPE local[10];                                             \
+    for (int i = 0; i < 10; i++)                                \
+      remote[i] = (TYPE)mype;                                   \
+    shmem_barrier_all();                                        \
+                                                                \
+    if (USE_CTX)                                                \
+      shmemx_ctx_##TYPENAME##_ibget(SHMEM_CTX_DEFAULT, local,   \
+                            remote, 1, 1, 1, 10,                \
+                            (mype + 1) % npes);                 \
+    else                                                        \
+      shmemx_##TYPENAME##_ibget(local, remote, 1, 1, 1, 10,     \
+                                    (mype + 1) % npes);         \
+                                                                \
+    for (int i = 0; i < 10; i++)                                \
+      if (local[i] != (TYPE)((mype + 1) % npes)) {              \
+        printf("PE %i received incorrect value with"            \
+               "TEST_SHMEM_IBGET(%d, %s)\n", mype,              \
+               (int)(USE_CTX), #TYPE);                          \
+        rc = EXIT_FAILURE;                                      \
+      }                                                         \
+  } while (false)
+
+int main(int argc, char* argv[]) {
+  shmem_init();
+
+  int rc = EXIT_SUCCESS;
+
+  TEST_SHMEM_IBGET(0, float, float);
+  TEST_SHMEM_IBGET(0, double, double);
+  TEST_SHMEM_IBGET(0, long double, longdouble);
+  TEST_SHMEM_IBGET(0, char, char);
+  TEST_SHMEM_IBGET(0, signed char, schar);
+  TEST_SHMEM_IBGET(0, short, short);
+  TEST_SHMEM_IBGET(0, int, int);
+  TEST_SHMEM_IBGET(0, long, long);
+  TEST_SHMEM_IBGET(0, long long, longlong);
+  TEST_SHMEM_IBGET(0, unsigned char, uchar);
+  TEST_SHMEM_IBGET(0, unsigned short, ushort);
+  TEST_SHMEM_IBGET(0, unsigned int, uint);
+  TEST_SHMEM_IBGET(0, unsigned long, ulong);
+  TEST_SHMEM_IBGET(0, unsigned long long, ulonglong);
+  TEST_SHMEM_IBGET(0, int8_t, int8);
+  TEST_SHMEM_IBGET(0, int16_t, int16);
+  TEST_SHMEM_IBGET(0, int32_t, int32);
+  TEST_SHMEM_IBGET(0, int64_t, int64);
+  TEST_SHMEM_IBGET(0, uint8_t, uint8);
+  TEST_SHMEM_IBGET(0, uint16_t, uint16);
+  TEST_SHMEM_IBGET(0, uint32_t, uint32);
+  TEST_SHMEM_IBGET(0, uint64_t, uint64);
+  TEST_SHMEM_IBGET(0, size_t, size);
+  TEST_SHMEM_IBGET(0, ptrdiff_t, ptrdiff);
+
+  TEST_SHMEM_IBGET(1, float, float);
+  TEST_SHMEM_IBGET(1, double, double);
+  TEST_SHMEM_IBGET(1, long double, longdouble);
+  TEST_SHMEM_IBGET(1, char, char);
+  TEST_SHMEM_IBGET(1, signed char, schar);
+  TEST_SHMEM_IBGET(1, short, short);
+  TEST_SHMEM_IBGET(1, int, int);
+  TEST_SHMEM_IBGET(1, long, long);
+  TEST_SHMEM_IBGET(1, long long, longlong);
+  TEST_SHMEM_IBGET(1, unsigned char, uchar);
+  TEST_SHMEM_IBGET(1, unsigned short, ushort);
+  TEST_SHMEM_IBGET(1, unsigned int, uint);
+  TEST_SHMEM_IBGET(1, unsigned long, ulong);
+  TEST_SHMEM_IBGET(1, unsigned long long, ulonglong);
+  TEST_SHMEM_IBGET(1, int8_t, int8);
+  TEST_SHMEM_IBGET(1, int16_t, int16);
+  TEST_SHMEM_IBGET(1, int32_t, int32);
+  TEST_SHMEM_IBGET(1, int64_t, int64);
+  TEST_SHMEM_IBGET(1, uint8_t, uint8);
+  TEST_SHMEM_IBGET(1, uint16_t, uint16);
+  TEST_SHMEM_IBGET(1, uint32_t, uint32);
+  TEST_SHMEM_IBGET(1, uint64_t, uint64);
+  TEST_SHMEM_IBGET(1, size_t, size);
+  TEST_SHMEM_IBGET(1, ptrdiff_t, ptrdiff);
+
+  shmem_finalize();
+  return rc;
+}

--- a/test/shmemx/cxx_test_shmem_ibput.cpp
+++ b/test/shmemx/cxx_test_shmem_ibput.cpp
@@ -1,0 +1,123 @@
+/*
+ *  This test program is derived from a unit test created by Nick Park.
+ *  The original unit test is a work of the U.S. Government and is not subject
+ *  to copyright protection in the United States.  Foreign copyrights may
+ *  apply.
+ *
+ *  Copyright (c) 2017 Intel Corporation. All rights reserved.
+ *  This software is available to you under the BSD license below:
+ *
+ *      Redistribution and use in source and binary forms, with or
+ *      without modification, are permitted provided that the following
+ *      conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <shmem.h>
+#include <shmemx.h>
+
+#define TEST_SHMEM_IBPUT(USE_CTX, TYPE, TYPENAME)               \
+  do {                                                          \
+    static TYPE remote[10];                                     \
+    const int mype = shmem_my_pe();                             \
+    const int npes = shmem_n_pes();                             \
+    TYPE local[10];                                             \
+    for (int i = 0; i < 10; i++)                                \
+      local[i] = (TYPE)mype;                                    \
+                                                                \
+    if (USE_CTX)                                                \
+      shmemx_ctx_##TYPENAME##_ibput(SHMEM_CTX_DEFAULT, remote,  \
+                              local, 1, 1, 1, 10,               \
+                              (mype + 1) % npes);               \
+    else                                                        \
+      shmemx_##TYPENAME##_ibput(remote, local, 1, 1, 1, 10,     \
+                                    (mype + 1) % npes);         \
+                                                                \
+    shmem_barrier_all();                                        \
+    for (int i = 0; i < 10; i++)                                \
+      if (remote[i] != (TYPE)((mype + npes - 1) % npes)) {      \
+        printf("PE %i received incorrect value with "           \
+               "TEST_SHMEM_IBPUT(%d, %s)\n", mype,              \
+               (int)(USE_CTX), #TYPE);                          \
+        rc = EXIT_FAILURE;                                      \
+      }                                                         \
+  } while (false)
+
+int main(int argc, char* argv[]) {
+  shmem_init();
+
+  int rc = EXIT_SUCCESS;
+  TEST_SHMEM_IBPUT(0, float, float);
+  TEST_SHMEM_IBPUT(0, double, double);
+  TEST_SHMEM_IBPUT(0, long double, longdouble);
+  TEST_SHMEM_IBPUT(0, char, char);
+  TEST_SHMEM_IBPUT(0, signed char, schar);
+  TEST_SHMEM_IBPUT(0, short, short);
+  TEST_SHMEM_IBPUT(0, int, int);
+  TEST_SHMEM_IBPUT(0, long, long);
+  TEST_SHMEM_IBPUT(0, long long, longlong);
+  TEST_SHMEM_IBPUT(0, unsigned char, uchar);
+  TEST_SHMEM_IBPUT(0, unsigned short, ushort);
+  TEST_SHMEM_IBPUT(0, unsigned int, uint);
+  TEST_SHMEM_IBPUT(0, unsigned long, ulong);
+  TEST_SHMEM_IBPUT(0, unsigned long long, ulonglong);
+  TEST_SHMEM_IBPUT(0, int8_t, int8);
+  TEST_SHMEM_IBPUT(0, int16_t, int16);
+  TEST_SHMEM_IBPUT(0, int32_t, int32);
+  TEST_SHMEM_IBPUT(0, int64_t, int64);
+  TEST_SHMEM_IBPUT(0, uint8_t, uint8);
+  TEST_SHMEM_IBPUT(0, uint16_t, uint16);
+  TEST_SHMEM_IBPUT(0, uint32_t, uint32);
+  TEST_SHMEM_IBPUT(0, uint64_t, uint64);
+  TEST_SHMEM_IBPUT(0, size_t, size);
+  TEST_SHMEM_IBPUT(0, ptrdiff_t, ptrdiff);
+
+  TEST_SHMEM_IBPUT(1, float, float);
+  TEST_SHMEM_IBPUT(1, double, double);
+  TEST_SHMEM_IBPUT(1, long double, longdouble);
+  TEST_SHMEM_IBPUT(1, char, char);
+  TEST_SHMEM_IBPUT(1, signed char, schar);
+  TEST_SHMEM_IBPUT(1, short, short);
+  TEST_SHMEM_IBPUT(1, int, int);
+  TEST_SHMEM_IBPUT(1, long, long);
+  TEST_SHMEM_IBPUT(1, long long, longlong);
+  TEST_SHMEM_IBPUT(1, unsigned char, uchar);
+  TEST_SHMEM_IBPUT(1, unsigned short, ushort);
+  TEST_SHMEM_IBPUT(1, unsigned int, uint);
+  TEST_SHMEM_IBPUT(1, unsigned long, ulong);
+  TEST_SHMEM_IBPUT(1, unsigned long long, ulonglong);
+  TEST_SHMEM_IBPUT(1, int8_t, int8);
+  TEST_SHMEM_IBPUT(1, int16_t, int16);
+  TEST_SHMEM_IBPUT(1, int32_t, int32);
+  TEST_SHMEM_IBPUT(1, int64_t, int64);
+  TEST_SHMEM_IBPUT(1, uint8_t, uint8);
+  TEST_SHMEM_IBPUT(1, uint16_t, uint16);
+  TEST_SHMEM_IBPUT(1, uint32_t, uint32);
+  TEST_SHMEM_IBPUT(1, uint64_t, uint64);
+  TEST_SHMEM_IBPUT(1, size_t, size);
+  TEST_SHMEM_IBPUT(1, ptrdiff_t, ptrdiff);
+
+  shmem_finalize();
+  return rc;
+}

--- a/test/shmemx/cxx_test_shmem_ibput.cpp
+++ b/test/shmemx/cxx_test_shmem_ibput.cpp
@@ -32,7 +32,6 @@
 
 #include <stdlib.h>
 #include <stdint.h>
-#include <stdbool.h>
 #include <stdio.h>
 #include <shmem.h>
 #include <shmemx.h>
@@ -48,11 +47,11 @@
                                                                 \
     if (USE_CTX)                                                \
       shmemx_ctx_##TYPENAME##_ibput(SHMEM_CTX_DEFAULT, remote,  \
-                              local, 1, 1, 1, 10,               \
-                              (mype + 1) % npes);               \
+                                    local, 1, 1, 1, 10,         \
+                                    (mype + 1) % npes);         \
     else                                                        \
       shmemx_##TYPENAME##_ibput(remote, local, 1, 1, 1, 10,     \
-                                    (mype + 1) % npes);         \
+                                (mype + 1) % npes);             \
                                                                 \
     shmem_barrier_all();                                        \
     for (int i = 0; i < 10; i++)                                \

--- a/test/shmemx/cxx_test_shmem_ibput.cpp
+++ b/test/shmemx/cxx_test_shmem_ibput.cpp
@@ -4,7 +4,7 @@
  *  to copyright protection in the United States.  Foreign copyrights may
  *  apply.
  *
- *  Copyright (c) 2017 Intel Corporation. All rights reserved.
+ *  Copyright (c) 2024 Intel Corporation. All rights reserved.
  *  This software is available to you under the BSD license below:
  *
  *      Redistribution and use in source and binary forms, with or


### PR DESCRIPTION
This PR adds tests for the [IBPUT/IBGET APIs](https://github.com/openshmem-org/specification/pull/448) (currently shmemx extensions, but ratified and to be included in a later OpenSHMEM spec version).