### PR TITLE
Deprecation fixes and cleanup

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@
 
 dnl Init Autoconf/Automake/Libtool
 
-AC_INIT([Sandia OpenSHMEM Test Suite], [1.4.3], [https://github.com/Sandia-OpenSHMEM/SOS])
+AC_INIT([Sandia OpenSHMEM Test Suite], [1.5.2], [https://github.com/Sandia-OpenSHMEM/SOS])
 AC_PREREQ([2.60])
 AC_CONFIG_AUX_DIR([config])
 AC_CONFIG_MACRO_DIR([config])
@@ -92,7 +92,7 @@ AM_CONDITIONAL([ENABLE_LENGTHY_TESTS], [test "$enable_lengthy_tests" = "yes"])
 
 AC_ARG_ENABLE([fortran],
     [AC_HELP_STRING([--disable-fortran],
-                    [Disable Fortran tests (default: enabled)])])
+                    [Disable Fortran tests (default: disabled)])])
 
 AC_ARG_ENABLE([cxx],
     [AC_HELP_STRING([--disable-cxx],
@@ -111,7 +111,7 @@ AC_ARG_ENABLE([shmemx],
                     [Enable SHMEM extensions tests (default:disabled)])])
 AM_CONDITIONAL([SHMEMX_TESTS], [test "$enable_shmemx" = "yes"])
 
-if test "$enable_fortran" != "no" ; then
+if test "$enable_fortran" = "yes" ; then
   AC_PROG_FC([oshfort])
 else
   FC=

--- a/configure.ac
+++ b/configure.ac
@@ -91,7 +91,7 @@ AC_ARG_ENABLE([lengthy-tests],
 AM_CONDITIONAL([ENABLE_LENGTHY_TESTS], [test "$enable_lengthy_tests" = "yes"])
 
 AC_ARG_ENABLE([fortran],
-    [AC_HELP_STRING([--disable-fortran],
+    [AC_HELP_STRING([--enable-fortran],
                     [Disable Fortran tests (default: disabled)])])
 
 AC_ARG_ENABLE([cxx],

--- a/test/unit/collect.c
+++ b/test/unit/collect.c
@@ -39,8 +39,6 @@
 int32_t src[MAX_NPES];
 int32_t dst[MAX_NPES*MAX_NPES];
 
-long pSync[SHMEM_COLLECT_SYNC_SIZE];
-
 int main(int argc, char **argv) {
     int me, npes;
     int i, j, errors = 0;
@@ -57,9 +55,6 @@ int main(int argc, char **argv) {
         shmem_finalize();
         return 0;
     }
-
-    for (i = 0; i < SHMEM_COLLECT_SYNC_SIZE; i++)
-        pSync[i] = SHMEM_SYNC_VALUE;
 
     for (i = 0; i < MAX_NPES; i++)
         src[i] = -1;

--- a/test/unit/cxx_shmem_test_all.c
+++ b/test/unit/cxx_shmem_test_all.c
@@ -30,6 +30,7 @@
  */
 
 #include <shmem.h>
+#include <stdio.h>
 
 int main(void)
 {

--- a/test/unit/cxx_shmem_test_all.c
+++ b/test/unit/cxx_shmem_test_all.c
@@ -41,14 +41,16 @@ int main(void)
     int *status = NULL;
 
     for (int i = 0; i < npes; i++)
-        shmem_int_p(&flags[mype], 1, i);
+        shmem_int_atomic_set(&flags[mype], 1, i);
 
     while (!shmem_int_test_all(flags, npes, status, SHMEM_CMP_EQ, 1));
 
     /* Check the flags array */
     for (int i = 0; i < npes; i++) {
-        if (flags[i] != 1)
+        if (flags[i] != 1) {
+            printf("[%d] incorrect value at index %d (%d)\n", mype, i, flags[i]);
             shmem_global_exit(1);
+        }
     }
     shmem_free(flags);
     shmem_finalize();

--- a/test/unit/mt_membar.c
+++ b/test/unit/mt_membar.c
@@ -25,7 +25,7 @@
  * SOFTWARE.
  */
 
-/* Multi-threaded tests for validation of memory barrier implemented in 
+/* Multi-threaded tests for validation of memory barrier implemented in
  * different synchronization routines.
 */
 
@@ -49,9 +49,6 @@ int me, npes, errors = 0, sum_error = 0;
 long lock = 0;
 
 pthread_barrier_t fencebar;
-
-long pSync[SHMEM_REDUCE_SYNC_SIZE];
-int pWrk[MAX(1, SHMEM_REDUCE_MIN_WRKDATA_SIZE)];
 
 static void * thread_main(void *arg) {
     int tid = *(int *) arg;
@@ -202,10 +199,6 @@ int main(int argc, char **argv) {
 
     me = shmem_my_pe();
     npes = shmem_n_pes();
-
-    for (i = 0; i < SHMEM_REDUCE_SYNC_SIZE; i++) {
-        pSync[i] = SHMEM_SYNC_VALUE;
-    }
 
     pthread_barrier_init(&fencebar, NULL, T);
 

--- a/test/unit/nop_collectives.c
+++ b/test/unit/nop_collectives.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 #include <shmem.h>
 
+#ifdef ENABLE_DEPRECATED_TESTS
 long bcast_psync[SHMEM_BCAST_SYNC_SIZE];
 long collect_psync[SHMEM_COLLECT_SYNC_SIZE];
 long reduce_psync[SHMEM_REDUCE_SYNC_SIZE];
@@ -36,6 +37,7 @@ long alltoall_psync[SHMEM_ALLTOALL_SYNC_SIZE];
 long alltoalls_psync[SHMEM_ALLTOALLS_SYNC_SIZE];
 
 int pwrk[SHMEM_REDUCE_MIN_WRKDATA_SIZE];
+#endif
 
 int main(void) {
     int me;

--- a/test/unit/repeated_syncs.c
+++ b/test/unit/repeated_syncs.c
@@ -30,36 +30,50 @@
 
 #define NREPS 50
 
+#ifdef ENABLE_DEPRECATED_TESTS
 long sync_psync0[SHMEM_BARRIER_SYNC_SIZE];
 long sync_psync1[SHMEM_BARRIER_SYNC_SIZE];
+#endif
 
 int main(void)
 {
-    int i, me, npes;
+    int i, me, npes, n_loops;
 
     shmem_init();
 
     me = shmem_my_pe();
     npes = shmem_n_pes();
 
+#ifdef ENABLE_DEPRECATED_TESTS
     for (i = 0; i < SHMEM_BARRIER_SYNC_SIZE; i++) {
         sync_psync0[i] = SHMEM_SYNC_VALUE;
         sync_psync1[i] = SHMEM_SYNC_VALUE;
     }
+    n_loops = me;
+#else
+    n_loops = 1;
+#endif
 
     shmem_sync_all();
 
     /* A total of npes tests are performed, where the active set in each test
-     * includes PEs i..npes-1 */
-    for (i = 0; i <= me; i++) {
+     * includes PEs i..npes-1.
+     * Teams must share the same value for "start" (according to the OpenSHMEM
+     * specification), so in that case sync across SHMEM_TEAM_WORLD. */
+    for (i = 0; i <= n_loops; i++) {
         int j;
 
         if (me == i)
             printf(" + iteration %d\n", i);
 
         /* Test that sync can be called repeatedly with the *same* pSync */
-        for (j = 0; j < NREPS; j++)
+        for (j = 0; j < NREPS; j++) {
+#ifdef ENABLE_DEPRECATED_TESTS
             shmem_sync(i, 0, npes-i, (i % 2) ? sync_psync0 : sync_psync1);
+#else
+            shmem_team_sync(SHMEM_TEAM_WORLD);
+#endif
+        }
     }
 
     shmem_finalize();

--- a/test/unit/self_collectives.c
+++ b/test/unit/self_collectives.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 #include <shmem.h>
 
+#ifdef ENABLE_DEPRECATED_TESTS
 long bcast_psync[SHMEM_BCAST_SYNC_SIZE];
 long collect_psync[SHMEM_COLLECT_SYNC_SIZE];
 long reduce_psync[SHMEM_REDUCE_SYNC_SIZE];
@@ -36,6 +37,7 @@ long alltoall_psync[SHMEM_ALLTOALL_SYNC_SIZE];
 long alltoalls_psync[SHMEM_ALLTOALLS_SYNC_SIZE];
 
 int pwrk[SHMEM_REDUCE_MIN_WRKDATA_SIZE];
+#endif
 
 #define CHECK(func, in, out)                                            \
     do {                                                                \
@@ -55,6 +57,7 @@ int main(void) {
     int i, errors = 0;
     int me;
 
+#ifdef ENABLE_DEPRECATED_TESTS
     for (i = 0; i < SHMEM_BCAST_SYNC_SIZE; i++)
         bcast_psync[i] = SHMEM_SYNC_VALUE;
 
@@ -72,6 +75,7 @@ int main(void) {
 
     for (i = 0; i < SHMEM_REDUCE_MIN_WRKDATA_SIZE; i++)
         pwrk[i] = 0;
+#endif
 
     shmem_init();
 
@@ -84,9 +88,10 @@ int main(void) {
     if (me == 0) printf(" + broadcast\n");
 
 #ifndef ENABLE_DEPRECATED_TESTS
-    /* Set up active set team (start=me, stride=1, size=1) for all tests*/
+    /* Set up a single-PE team (start=0, stride=1, size=1) for all team tests. */
+    /* Active-set tests are permitted to start at "self" (start=me, stride=1, size=1) */
     shmem_team_t new_team;
-    shmem_team_split_strided(SHMEM_TEAM_WORLD, me, 1, 1, NULL, 0, &new_team);
+    shmem_team_split_strided(SHMEM_TEAM_WORLD, 0, 1, 1, NULL, 0, &new_team);
 #endif
 
     in_32 = me; out_32 = -1;
@@ -94,9 +99,10 @@ int main(void) {
     shmem_broadcast32(&in_32, &out_32, 1, 0, me, 0, 1, bcast_psync);
     CHECK("shmem_broadcast32", -1, out_32);
 #else
-    if (new_team != SHMEM_TEAM_INVALID)
+    if (new_team != SHMEM_TEAM_INVALID) {
         shmem_int32_broadcast(new_team, &in_32, &out_32, 1, 0);
-    CHECK("shmem_int32_broadcast", -1, out_32);
+        CHECK("shmem_int32_broadcast", -1, out_32);
+    }
 #endif
     shmem_barrier_all();
 
@@ -105,9 +111,10 @@ int main(void) {
     shmem_broadcast64(&in_64, &out_64, 1, 0, me, 0, 1, bcast_psync);
     CHECK("shmem_broadcast64", -1, out_64);
 #else
-    if (new_team != SHMEM_TEAM_INVALID)
+    if (new_team != SHMEM_TEAM_INVALID) {
         shmem_int64_broadcast(new_team, &in_64, &out_64, 1, 0);
-    CHECK("shmem_int64_broadcast", -1, out_64);
+        CHECK("shmem_int64_broadcast", -1, out_64);
+    }
 #endif
     shmem_barrier_all();
 
@@ -119,9 +126,10 @@ int main(void) {
     shmem_fcollect32(&in_32, &out_32, 1, me, 0, 1, collect_psync);
     CHECK("shmem_fcollect32", in_32, out_32);
 #else
-    if (new_team != SHMEM_TEAM_INVALID)
+    if (new_team != SHMEM_TEAM_INVALID) {
         shmem_int32_fcollect(new_team, &in_32, &out_32, 1);
-    CHECK("shmem_int32_fcollect", in_32, out_32);
+        CHECK("shmem_int32_fcollect", in_32, out_32);
+    }
 #endif
     shmem_barrier_all();
 
@@ -130,9 +138,10 @@ int main(void) {
     shmem_fcollect64(&in_64, &out_64, 1, me, 0, 1, collect_psync);
     CHECK("shmem_fcollect64", in_64, out_64);
 #else
-    if (new_team != SHMEM_TEAM_INVALID)
+    if (new_team != SHMEM_TEAM_INVALID) {
         shmem_int64_fcollect(new_team, &in_64, &out_64, 1);
-    CHECK("shmem_int64_fcollect", in_64, out_64);
+        CHECK("shmem_int64_fcollect", in_64, out_64);
+    }
 #endif
     shmem_barrier_all();
 
@@ -141,9 +150,10 @@ int main(void) {
     shmem_collect32(&in_32, &out_32, 1, me, 0, 1, collect_psync);
     CHECK("shmem_collect32", in_32, out_32);
 #else
-    if (new_team != SHMEM_TEAM_INVALID)
+    if (new_team != SHMEM_TEAM_INVALID) {
         shmem_int32_collect(new_team, &in_32, &out_32, 1);
-    CHECK("shmem_int32_collect", in_32, out_32);
+        CHECK("shmem_int32_collect", in_32, out_32);
+    }
 #endif
     shmem_barrier_all();
 
@@ -152,9 +162,10 @@ int main(void) {
     shmem_collect64(&in_64, &out_64, 1, me, 0, 1, collect_psync);
     CHECK("shmem_collect64", in_64, out_64);
 #else
-    if (new_team != SHMEM_TEAM_INVALID)
+    if (new_team != SHMEM_TEAM_INVALID) {
         shmem_int64_collect(new_team, &in_64, &out_64, 1);
-    CHECK("shmem_int64_collect", in_64, out_64);
+        CHECK("shmem_int64_collect", in_64, out_64);
+    }
 #endif
     shmem_barrier_all();
 
@@ -167,9 +178,10 @@ int main(void) {
     CHECK("shmem_int_and_to_all", in, out);
 #else
     uin = (unsigned int) me; uout = -1U;
-    if (new_team != SHMEM_TEAM_INVALID)
+    if (new_team != SHMEM_TEAM_INVALID) {
         shmem_uint_and_reduce(new_team, &uin, &uout, 1);
-    CHECK("shmem_uint_and_reduce", uin, uout);
+        CHECK("shmem_uint_and_reduce", uin, uout);
+    }
 #endif
     shmem_barrier_all();
 
@@ -179,9 +191,10 @@ int main(void) {
     CHECK("shmem_int_or_to_all", in, out);
 #else
     uin = (unsigned int) me; uout = -1U;
-    if (new_team != SHMEM_TEAM_INVALID)
+    if (new_team != SHMEM_TEAM_INVALID) {
         shmem_uint_or_reduce(new_team, &uin, &uout, 1);
-    CHECK("shmem_uint_or_reduce", uin, uout);
+        CHECK("shmem_uint_or_reduce", uin, uout);
+    }
 #endif
     shmem_barrier_all();
 
@@ -191,9 +204,10 @@ int main(void) {
     CHECK("shmem_int_xor_to_all", in, out);
 #else
     uin = (unsigned int) me; uout = -1U;
-    if (new_team != SHMEM_TEAM_INVALID)
+    if (new_team != SHMEM_TEAM_INVALID) {
         shmem_uint_xor_reduce(new_team, &uin, &uout, 1);
-    CHECK("shmem_uint_xor_reduce", uin, uout);
+        CHECK("shmem_uint_xor_reduce", uin, uout);
+    }
 #endif
     shmem_barrier_all();
 
@@ -202,9 +216,10 @@ int main(void) {
     shmem_int_min_to_all(&in, &out, 1, me, 0, 1, pwrk, reduce_psync);
     CHECK("shmem_int_min_to_all", in, out);
 #else
-    if (new_team != SHMEM_TEAM_INVALID)
+    if (new_team != SHMEM_TEAM_INVALID) {
         shmem_int_min_reduce(new_team, &in, &out, 1);
-    CHECK("shmem_int_min_reduce", in, out);
+        CHECK("shmem_int_min_reduce", in, out);
+    }
 #endif
     shmem_barrier_all();
 
@@ -213,9 +228,10 @@ int main(void) {
     shmem_int_max_to_all(&in, &out, 1, me, 0, 1, pwrk, reduce_psync);
     CHECK("shmem_int_max_to_all", in, out);
 #else
-    if (new_team != SHMEM_TEAM_INVALID)
+    if (new_team != SHMEM_TEAM_INVALID) {
         shmem_int_max_reduce(new_team, &in, &out, 1);
-    CHECK("shmem_int_max_to_all", in, out);
+        CHECK("shmem_int_max_to_all", in, out);
+    }
 #endif
     shmem_barrier_all();
 
@@ -224,9 +240,10 @@ int main(void) {
     shmem_int_sum_to_all(&in, &out, 1, me, 0, 1, pwrk, reduce_psync);
     CHECK("shmem_int_sum_to_all", in, out);
 #else
-    if (new_team != SHMEM_TEAM_INVALID)
+    if (new_team != SHMEM_TEAM_INVALID) {
         shmem_int_sum_reduce(new_team, &in, &out, 1);
-    CHECK("shmem_int_sum_reduce", in, out);
+        CHECK("shmem_int_sum_reduce", in, out);
+    }
 #endif
     shmem_barrier_all();
 
@@ -235,9 +252,10 @@ int main(void) {
     shmem_int_prod_to_all(&in, &out, 1, me, 0, 1, pwrk, reduce_psync);
     CHECK("shmem_int_prod_to_all", in, out);
 #else
-    if (new_team != SHMEM_TEAM_INVALID)
+    if (new_team != SHMEM_TEAM_INVALID) {
         shmem_int_prod_reduce(new_team, &in, &out, 1);
-    CHECK("shmem_int_prod_reduce", in, out);
+        CHECK("shmem_int_prod_reduce", in, out);
+    }
 #endif
     shmem_barrier_all();
 
@@ -249,9 +267,10 @@ int main(void) {
     shmem_alltoall32(&in_32, &out_32, 1, me, 0, 1, alltoall_psync);
     CHECK("shmem_alltoall32", in_32, out_32);
 #else
-    if (new_team != SHMEM_TEAM_INVALID)
+    if (new_team != SHMEM_TEAM_INVALID) {
         shmem_int32_alltoall(new_team, &in_32, &out_32, 1);
-    CHECK("shmem_int32_alltoall", in_32, out_32);
+        CHECK("shmem_int32_alltoall", in_32, out_32);
+    }
 #endif
     shmem_barrier_all();
 
@@ -260,9 +279,10 @@ int main(void) {
     shmem_alltoall64(&in_64, &out_64, 1, me, 0, 1, alltoall_psync);
     CHECK("shmem_alltoall64", in_64, out_64);
 #else
-    if (new_team != SHMEM_TEAM_INVALID)
+    if (new_team != SHMEM_TEAM_INVALID) {
         shmem_int64_alltoall(new_team, &in_64, &out_64, 1);
-    CHECK("shmem_int64_alltoall", in_64, out_64);
+        CHECK("shmem_int64_alltoall", in_64, out_64);
+    }
 #endif
     shmem_barrier_all();
 
@@ -271,9 +291,10 @@ int main(void) {
     shmem_alltoalls32(&in_32, &out_32, 1, 1, 1, me, 0, 1, alltoalls_psync);
     CHECK("shmem_alltoalls32", in_32, out_32);
 #else
-    if (new_team != SHMEM_TEAM_INVALID)
+    if (new_team != SHMEM_TEAM_INVALID) {
         shmem_int32_alltoalls(new_team, &in_32, &out_32, 1, 1, 1);
-    CHECK("shmem_int32_alltoalls", in_32, out_32);
+        CHECK("shmem_int32_alltoalls", in_32, out_32);
+    }
 #endif
     shmem_barrier_all();
 
@@ -282,9 +303,10 @@ int main(void) {
     shmem_alltoalls64(&in_64, &out_64, 1, 1, 1, me, 0, 1, alltoalls_psync);
     CHECK("shmem_alltoalls64", in_64, out_64);
 #else
-    if (new_team != SHMEM_TEAM_INVALID)
+    if (new_team != SHMEM_TEAM_INVALID) {
         shmem_int64_alltoalls(new_team, &in_64, &out_64, 1, 1, 1);
-    CHECK("shmem_int64_alltoalls", in_64, out_64);
+        CHECK("shmem_int64_alltoalls", in_64, out_64);
+    }
 #endif
     shmem_barrier_all();
 

--- a/test/unit/spam.c
+++ b/test/unit/spam.c
@@ -396,14 +396,16 @@ bcast(int *target, int *src, int elements, int me, int npes, int loops)
 {
     int i;
     double start_time, elapsed_time;
-    long *ps, *pSync, *pSync1;
     long total_bytes = loops * elements * sizeof(*src);
 
+#ifdef ENABLE_DEPRECATED_TESTS
+    long *ps, *pSync, *pSync1;
     pSync = (long*)shmem_malloc( 2 * sizeof(long) * SHMEM_BCAST_SYNC_SIZE );
     pSync1 = &pSync[SHMEM_BCAST_SYNC_SIZE];
     for (i = 0; i < SHMEM_BCAST_SYNC_SIZE; i++) {
         pSync[i] = pSync1[i] = SHMEM_SYNC_VALUE;
     }
+#endif
 
     if (me==0 && Verbose) {
         fprintf(stdout, "%s: %d loops of broadcast32(%ld bytes) over %d PEs: ",
@@ -415,8 +417,12 @@ bcast(int *target, int *src, int elements, int me, int npes, int loops)
 
     start_time = tests_sos_wtime();
     for(i = 0; i < loops; i++) {
+#ifdef ENABLE_DEPRECATED_TESTS
         ps = (i & 1) ? pSync1 : pSync;
         shmem_broadcast32( target, src, elements, 0, 0, 0, npes, ps );
+#else
+        shmem_int_broadcast( SHMEM_TEAM_WORLD, target, src, elements, 0 );
+#endif
     }
     elapsed_time = tests_sos_wtime() - start_time;
 
@@ -428,7 +434,9 @@ bcast(int *target, int *src, int elements, int me, int npes, int loops)
                ((double)total_bytes/(1024.0*1024.0)) / elapsed_time );
     }
     shmem_barrier_all();
+#ifdef ENABLE_DEPRECATED_TESTS
     shmem_free( pSync );
+#endif
 }
 
 
@@ -438,13 +446,15 @@ collect(int *target, int *src, int elements, int me, int npes, int loops)
     int i;
     double start_time, elapsed_time;
     long total_bytes = loops * elements * sizeof(*src);
-    long *ps, *pSync, *pSync1;
 
+#ifdef ENABLE_DEPRECATED_TESTS
+    long *ps, *pSync, *pSync1;
     pSync = (long*) shmem_malloc( 2 * sizeof(long) * SHMEM_COLLECT_SYNC_SIZE );
     pSync1 = &pSync[SHMEM_COLLECT_SYNC_SIZE];
     for (i = 0; i < SHMEM_COLLECT_SYNC_SIZE; i++) {
         pSync[i] = pSync1[i] = SHMEM_SYNC_VALUE;
     }
+#endif
     target = (int *) shmem_malloc( elements * sizeof(*target) * npes );
 
     if (me==0 && Verbose) {
@@ -457,8 +467,12 @@ collect(int *target, int *src, int elements, int me, int npes, int loops)
 
     start_time = tests_sos_wtime();
     for(i = 0; i < loops; i++) {
+#ifdef ENABLE_DEPRECATED_TESTS
         ps = (i & 1) ? pSync1 : pSync;
         shmem_collect32( target, src, elements, 0, 0, npes, ps );
+#else
+        shmem_int_collect( SHMEM_TEAM_WORLD, target, src, elements );
+#endif
     }
     elapsed_time = tests_sos_wtime() - start_time;
 
@@ -471,7 +485,9 @@ collect(int *target, int *src, int elements, int me, int npes, int loops)
     }
     shmem_barrier_all();
     shmem_free(target);
+#ifdef ENABLE_DEPRECATED_TESTS
     shmem_free( pSync );
+#endif
     shmem_barrier_all();
 }
 
@@ -483,13 +499,15 @@ fcollect(int *target, int *src, int elements, int me, int npes, int loops)
     int i;
     double start_time, elapsed_time;
     long total_bytes = loops * elements * sizeof(*src);
-    long *ps, *pSync, *pSync1;
 
+#ifdef ENABLE_DEPRECATED_TESTS
+    long *ps, *pSync, *pSync1;
     pSync = (long*) shmem_malloc( 2 * sizeof(long) * SHMEM_COLLECT_SYNC_SIZE );
     pSync1 = &pSync[SHMEM_COLLECT_SYNC_SIZE];
     for (i = 0; i < SHMEM_COLLECT_SYNC_SIZE; i++) {
         pSync[i] = pSync1[i] = SHMEM_SYNC_VALUE;
     }
+#endif
     target = (int *) shmem_malloc( elements * sizeof(*target) * npes );
 
     if (me==0 && Verbose) {
@@ -502,8 +520,12 @@ fcollect(int *target, int *src, int elements, int me, int npes, int loops)
 
     start_time = tests_sos_wtime();
     for(i = 0; i < loops; i++) {
+#ifdef ENABLE_DEPRECATED_TESTS
         ps = &pSync[(i&1)];
         shmem_fcollect32( target, src, elements, 0, 0, npes, ps );
+#else
+        shmem_int_fcollect( SHMEM_TEAM_WORLD, target, src, elements );
+#endif
     }
     elapsed_time = tests_sos_wtime() - start_time;
 
@@ -516,7 +538,9 @@ fcollect(int *target, int *src, int elements, int me, int npes, int loops)
     }
     shmem_barrier_all();
     shmem_free(target);
+#ifdef ENABLE_DEPRECATED_TESTS
     shmem_free( pSync );
+#endif
     shmem_barrier_all();
 }
 


### PR DESCRIPTION
Some unit tests still rely on deprecated APIs/constants, so this PR separates those out.  They can be enabled at configure time with `--enable-deprecated-tests`.

This also corrects the version number to 1.5.2 and disables Fortran tests by default.  They can be enabled at configure time with `--enable-fortran`.
