### PR TITLE
configury: updates/maintenance aligning w/ SOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -92,7 +92,7 @@ AM_CONDITIONAL([ENABLE_LENGTHY_TESTS], [test "$enable_lengthy_tests" = "yes"])
 
 AC_ARG_ENABLE([fortran],
     [AS_HELP_STRING([--enable-fortran],
-                    [Disable Fortran tests (default: disabled)])])
+                    [Enable building the Fortran tests (default: disabled)])])
 
 AC_ARG_ENABLE([cxx],
     [AS_HELP_STRING([--disable-cxx],


### PR DESCRIPTION
Related to https://github.com/Sandia-OpenSHMEM/SOS/pull/1130, eliminates some warnings about obsolete autoconf macros.  These apparently cause problems in Spack's out-of-the-box experience.

My tentative plan is to merge this _after_ merging PR #52, then tagging `tests-sos` with `v1.5.3`, then re-applying PR #46.